### PR TITLE
New provider interface to decouple from HGP

### DIFF
--- a/qiskit_ibm/api/rest/account.py
+++ b/qiskit_ibm/api/rest/account.py
@@ -109,7 +109,6 @@ class Account(RestAdapterBase):
             JSON response.
         """
         url = self.get_url('jobs_status')
-
         order = 'DESC' if descending else 'ASC'
 
         query = {

--- a/qiskit_ibm/credentials/__init__.py
+++ b/qiskit_ibm/credentials/__init__.py
@@ -42,9 +42,9 @@ from typing import Dict, Optional, Tuple, Any
 import logging
 
 from .credentials import Credentials
-from .hubgroupproject import HubGroupProject
+from .hub_group_project_id import HubGroupProjectID
 from .exceptions import (CredentialsError, InvalidCredentialsFormatError,
-                         CredentialsNotFoundError, HubGroupProjectInvalidStateError)
+                         CredentialsNotFoundError, HubGroupProjectIDInvalidStateError)
 from .configrc import read_credentials_from_qiskitrc, store_credentials, store_preferences
 from .environ import read_credentials_from_environ
 
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 
 def discover_credentials(
         qiskitrc_filename: Optional[str] = None
-) -> Tuple[Dict[HubGroupProject, Credentials], Dict]:
+) -> Tuple[Dict[HubGroupProjectID, Credentials], Dict]:
     """Automatically discover credentials for IBM Quantum.
 
     This method looks for credentials in the following places in order and
@@ -67,7 +67,7 @@ def discover_credentials(
             file. If ``None``, ``$HOME/.qiskitrc/qiskitrc`` is used.
 
     Raises:
-        HubGroupProjectInvalidStateError: If the default provider stored on
+        HubGroupProjectIDInvalidStateError: If the default provider stored on
             disk could not be parsed.
 
     Returns:
@@ -76,8 +76,8 @@ def discover_credentials(
         for the found credentials is ``{credentials_unique_id: Credentials}``,
         whereas the preferences is ``{credentials_unique_id: {category: {key: val}}}``.
     """
-    credentials_: Dict[HubGroupProject, Credentials] = {}
-    preferences: Dict[HubGroupProject, Dict] = {}
+    credentials_: Dict[HubGroupProjectID, Credentials] = {}
+    preferences: Dict[HubGroupProjectID, Dict] = {}
 
     # dict[str:function] that defines the different locations for looking for
     # credentials, and their precedence order.

--- a/qiskit_ibm/credentials/credentials.py
+++ b/qiskit_ibm/credentials/credentials.py
@@ -17,7 +17,7 @@ import re
 from typing import Dict, Tuple, Optional, Any
 from requests_ntlm import HttpNtlmAuth
 
-from .hubgroupproject import HubGroupProject
+from .hub_group_project_id import HubGroupProjectID
 
 
 REGEX_IBM_HUBS = (
@@ -52,7 +52,7 @@ class Credentials:
             services: Optional[Dict] = None,
             access_token: Optional[str] = None,
             preferences: Optional[Dict] = None,
-            default_provider: Optional[HubGroupProject] = None,
+            default_provider: Optional[HubGroupProjectID] = None,
     ) -> None:
         """Credentials constructor.
 
@@ -99,16 +99,16 @@ class Credentials:
             return False
         return (self.token == other.token) & (self.unique_id() == other.unique_id())
 
-    def unique_id(self) -> HubGroupProject:
+    def unique_id(self) -> HubGroupProjectID:
         """Return a value that uniquely identifies these credentials.
 
         By convention, two credentials that have the same hub, group,
         and project are considered equivalent.
 
         Returns:
-            A ``HubGroupProject`` instance.
+            A ``HubGroupProjectID`` instance.
         """
-        return HubGroupProject(self.hub, self.group, self.project)
+        return HubGroupProjectID(self.hub, self.group, self.project)
 
     def connection_parameters(self) -> Dict[str, Any]:
         """Construct connection related parameters.

--- a/qiskit_ibm/credentials/environ.py
+++ b/qiskit_ibm/credentials/environ.py
@@ -16,7 +16,7 @@ import os
 from typing import Dict
 
 from .credentials import Credentials
-from .hubgroupproject import HubGroupProject
+from .hub_group_project_id import HubGroupProjectID
 
 VARIABLES_MAP = {
     'QISKIT_IBM_API_TOKEN': 'token',
@@ -28,7 +28,7 @@ VARIABLES_MAP = {
 """Dictionary that maps `ENV_VARIABLE_NAME` to credential parameter."""
 
 
-def read_credentials_from_environ() -> Dict[HubGroupProject, Credentials]:
+def read_credentials_from_environ() -> Dict[HubGroupProjectID, Credentials]:
     """Extract credentials from the environment variables.
 
     Returns:
@@ -58,7 +58,7 @@ def read_credentials_from_environ() -> Dict[HubGroupProject, Credentials]:
                 project = os.getenv(envar_name)
 
     if all([hub, group, project]):
-        credentials_dict['default_provider'] = HubGroupProject(hub, group, project)
+        credentials_dict['default_provider'] = HubGroupProjectID(hub, group, project)
 
     credentials = Credentials(**credentials_dict)  # type: ignore[arg-type]
     return {credentials.unique_id(): credentials}

--- a/qiskit_ibm/credentials/exceptions.py
+++ b/qiskit_ibm/credentials/exceptions.py
@@ -30,11 +30,11 @@ class CredentialsNotFoundError(CredentialsError):
     pass
 
 
-class HubGroupProjectError(IBMError):
-    """Base class for errors raised by the hubgroupproject module."""
+class HubGroupProjectIDError(IBMError):
+    """Base class for errors raised by the hub_group_project_id module."""
     pass
 
 
-class HubGroupProjectInvalidStateError(HubGroupProjectError):
-    """Errors raised when a HubGroupProject is in an invalid state for an operation."""
+class HubGroupProjectIDInvalidStateError(HubGroupProjectIDError):
+    """Errors raised when a HubGroupProjectID is in an invalid state for an operation."""
     pass

--- a/qiskit_ibm/credentials/hub_group_project_id.py
+++ b/qiskit_ibm/credentials/hub_group_project_id.py
@@ -10,15 +10,15 @@
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
 
-"""Model for representing a hub/group/project tuple."""
+"""Model for representing a hub/group/project id tuple."""
 
 from typing import Tuple, Optional
 
-from .exceptions import HubGroupProjectInvalidStateError
+from .exceptions import HubGroupProjectIDInvalidStateError
 
 
-class HubGroupProject:
-    """Class for representing a hub/group/project."""
+class HubGroupProjectID:
+    """Class for representing a hub/group/project id."""
 
     def __init__(
             self,
@@ -26,39 +26,39 @@ class HubGroupProject:
             group: str = None,
             project: str = None
     ) -> None:
-        """HubGroupProject constructor."""
+        """HubGroupProjectID constructor."""
         self.hub = hub
         self.group = group
         self.project = project
 
     @classmethod
-    def from_stored_format(cls, hgp: str) -> 'HubGroupProject':
-        """Instantiates a ``HubGroupProject`` instance from a string.
+    def from_stored_format(cls, hgp_id: str) -> 'HubGroupProjectID':
+        """Instantiates a ``HubGroupProjectID`` instance from a string.
 
         Note:
             The format for the string is ``<hub_name>/<group_name>/<project_name>``.
             It is saved inside the configuration file to specify a default provider.
 
         Raises:
-            HubGroupProjectInvalidStateError: If the specified string, used for conversion, is
+            HubGroupProjectIDInvalidStateError: If the specified string, used for conversion, is
                 in an invalid format.
 
         Returns:
-            A ``HubGroupProject`` instance.
+            A ``HubGroupProjectID`` instance.
         """
         try:
-            hub, group, project = hgp.split('/')
+            hub, group, project = hgp_id.split('/')
             if (not hub) or (not group) or (not project):
-                raise HubGroupProjectInvalidStateError(
-                    'The hub/group/project "{}" is in an invalid format. '
+                raise HubGroupProjectIDInvalidStateError(
+                    'The hub/group/project id "{}" is in an invalid format. '
                     'Every field must be specified: hub = "{}", group = "{}", project = "{}".'
-                    .format(hgp, hub, group, project))
+                    .format(hgp_id, hub, group, project))
         except ValueError:
             # Not enough, or too many, values were provided.
-            raise HubGroupProjectInvalidStateError(
-                'The hub/group/project "{}" is in an invalid format. '
+            raise HubGroupProjectIDInvalidStateError(
+                'The hub/group/project id "{}" is in an invalid format. '
                 'Use the "<hub_name>/<group_name>/<project_name>" format.'
-                .format(hgp))
+                .format(hgp_id))
 
         return cls(hub, group, project)
 
@@ -66,43 +66,43 @@ class HubGroupProject:
     def from_credentials(
             cls,
             credentials_obj: 'Credentials'  # type: ignore
-    ) -> 'HubGroupProject':
-        """Instantiates a ``HubGroupProject`` instance from ``Credentials``.
+    ) -> 'HubGroupProjectID':
+        """Instantiates a ``HubGroupProjectID`` instance from ``Credentials``.
 
         Returns:
-            A ``HubGroupProject`` instance.
+            A ``HubGroupProjectID`` instance.
         """
         hub, group, project = [getattr(credentials_obj, key)
                                for key in ['hub', 'group', 'project']]
         return cls(hub, group, project)
 
     def to_stored_format(self) -> str:
-        """Returns ``HubGroupProject`` as a string.
+        """Returns ``HubGroupProjectID`` as a string.
 
         Note:
             The format of the string returned is ``<hub_name>/<group_name>/<project_name>``.
-            It is used to save a default provider in the configuration file.
+            It is used to save a default hub/group/project in the configuration file.
 
         Raises:
-            HubGroupProjectInvalidStateError: If the ``HubGroupProject`` cannot be
+            HubGroupProjectIDInvalidStateError: If the ``HubGroupProjectID`` cannot be
                 represented as a string to store on disk (i.e. Some of the hub, group,
                 project fields are empty strings or ``None``).
 
         Returns:
-             A string representation of the hub/group/project, used to store to disk.
+             A string representation of the hub/group/project id, used to store to disk.
         """
         if (not self.hub) or (not self.group) or (not self.project):
-            raise HubGroupProjectInvalidStateError(
-                'The hub/group/project cannot be represented in the stored format. '
+            raise HubGroupProjectIDInvalidStateError(
+                'The hub/group/project id cannot be represented in the stored format. '
                 'Every field must be specified: hub = "{}", group = "{}", project = "{}".'
                 .format(self.hub, self.group, self.project))
         return '/'.join([self.hub, self.group, self.project])
 
     def to_tuple(self) -> Tuple[Optional[str], Optional[str], Optional[str]]:
-        """Returns ``HubGroupProject`` as a tuple."""
+        """Returns ``HubGroupProjectID`` as a tuple."""
         return self.hub, self.group, self.project
 
-    def __eq__(self, other: 'HubGroupProject') -> bool:  # type: ignore
+    def __eq__(self, other: 'HubGroupProjectID') -> bool:  # type: ignore
         """Two instances are equal if they define the same hub, group, project."""
         return (self.hub, self.group, self.project) == (other.hub, other.group, other.project)
 

--- a/qiskit_ibm/hub_group_project.py
+++ b/qiskit_ibm/hub_group_project.py
@@ -39,7 +39,13 @@ class HubGroupProject:
             provider: 'ibm_provider.IBMProvider',
             is_open: bool
     ) -> None:
-        """HubGroupProject constructor"""
+        """HubGroupProject constructor
+
+        Args:
+            credentials: IBM Quantum credentials.
+            provider: IBM Quantum account provider.
+            is_open: True means open access, False means premium
+        """
         self.credentials = credentials
         self._provider = provider
         self.is_open = is_open

--- a/qiskit_ibm/hub_group_project.py
+++ b/qiskit_ibm/hub_group_project.py
@@ -1,0 +1,136 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""A hub, group and project in an IBM Quantum account."""
+
+import logging
+from collections import OrderedDict
+import traceback
+from typing import Any, Dict, Optional
+
+from qiskit.providers.backend import BackendV1 as Backend
+from qiskit.providers.models import PulseBackendConfiguration, QasmBackendConfiguration
+from qiskit_ibm import ibm_provider  # pylint: disable=unused-import
+from qiskit_ibm.exceptions import IBMInputValueError
+
+from .utils.json_decoder import decode_backend_configuration
+from .ibm_backend import IBMBackend, IBMSimulator
+from .api.clients import AccountClient
+from .credentials import Credentials
+
+logger = logging.getLogger(__name__)
+
+
+class HubGroupProject:
+    """Represents a hub/group/project with IBM Quantum backends and services associated with it."""
+
+    def __init__(
+            self,
+            credentials: Credentials,
+            provider: 'ibm_provider.IBMProvider',
+            is_open: bool
+    ) -> None:
+        """HubGroupProject constructor"""
+        self.credentials = credentials
+        self._provider = provider
+        self.is_open = is_open
+        self._api_client = AccountClient(self.credentials,
+                                         **self.credentials.connection_parameters())
+        # Initialize the internal list of backends.
+        self._backends: Dict[str, IBMBackend] = {}
+        self._service_urls = {
+            'backend': self.credentials.url,
+            'experiment': self.credentials.experiment_url,
+            'random': self.credentials.extractor_url,
+            'runtime': self.credentials.runtime_url
+        }
+
+    @property
+    def backends(self) -> Dict[str, IBMBackend]:
+        """Gets the backends for the hub/group/project, if not loaded.
+
+        Returns:
+            Dict[str, IBMBackend]: the backends
+        """
+        if not self._backends:
+            self._backends = self._discover_remote_backends()
+        return self._backends
+
+    @backends.setter
+    def backends(self, value: Dict[str, IBMBackend]) -> None:
+        """Sets the value for the hub/group/project's backends.
+
+        Args:
+            value: the backends
+        """
+        self._backends = value
+
+    def _discover_remote_backends(self, timeout: Optional[float] = None) -> Dict[str, IBMBackend]:
+        """Return the remote backends available for this hub/group/project.
+
+        Args:
+            timeout: Maximum number of seconds to wait for the discovery of
+                remote backends.
+
+        Returns:
+            A dict of the remote backend instances, keyed by backend name.
+        """
+        ret = OrderedDict()  # type: ignore[var-annotated]
+        configs_list = self._api_client.list_backends(timeout=timeout)
+        for raw_config in configs_list:
+            # Make sure the raw_config is of proper type
+            if not isinstance(raw_config, dict):
+                logger.warning("An error occurred when retrieving backend "
+                               "information. Some backends might not be available.")
+                continue
+            try:
+                decode_backend_configuration(raw_config)
+                try:
+                    config = PulseBackendConfiguration.from_dict(raw_config)
+                except (KeyError, TypeError):
+                    config = QasmBackendConfiguration.from_dict(raw_config)
+                backend_cls = IBMSimulator if config.simulator else IBMBackend
+                ret[config.backend_name] = backend_cls(
+                    configuration=config,
+                    provider=self._provider,
+                    credentials=self.credentials,
+                    api_client=self._api_client)
+            except Exception:  # pylint: disable=broad-except
+                logger.warning(
+                    'Remote backend "%s" for provider %s could not be instantiated due to an '
+                    'invalid config: %s',
+                    raw_config.get('backend_name', raw_config.get('name', 'unknown')),
+                    repr(self), traceback.format_exc())
+        return ret
+
+    def get_backend(self, name: str) -> Optional[Backend]:
+        """Get backend by name."""
+        return self._backends.get(name, None)
+
+    def has_service(self, name: str) -> bool:
+        """Check if hgp has service by name."""
+        if name not in self._service_urls:
+            raise IBMInputValueError(f"Unknown service {name} specified.")
+        return self._service_urls[name] is not None
+
+    def __repr__(self) -> str:
+        credentials_info = "hub='{}', group='{}', project='{}'".format(
+            self.credentials.hub, self.credentials.group, self.credentials.project)
+        return "<{}({})>".format(self.__class__.__name__, credentials_info)
+
+    def __eq__(
+            self,
+            other: Any
+    ) -> bool:
+        if not isinstance(other, HubGroupProject):
+            return False
+        return self.credentials == other.credentials

--- a/qiskit_ibm/ibm_backend.py
+++ b/qiskit_ibm/ibm_backend.py
@@ -33,7 +33,6 @@ from qiskit.providers.models import (BackendStatus, BackendProperties,
 from qiskit.tools.events.pubsub import Publisher
 from qiskit.providers.models import (QasmBackendConfiguration,
                                      PulseBackendConfiguration)
-
 from qiskit_ibm import ibm_provider  # pylint: disable=unused-import
 
 from .apiconstants import ApiJobStatus, API_JOB_FINAL_STATES
@@ -114,7 +113,7 @@ class IBMBackend(Backend):
 
         Args:
             configuration: Backend configuration.
-            provider: IBM Quantum account provider
+            provider: IBM Quantum account provider.
             credentials: IBM Quantum credentials.
             api_client: IBM Quantum client used to communicate with the server.
         """
@@ -619,12 +618,7 @@ class IBMBackend(Backend):
         return self._configuration
 
     def __repr__(self) -> str:
-        credentials_info = ''
-        if self.hub:
-            credentials_info = "hub='{}', group='{}', project='{}'".format(
-                self.hub, self.group, self.project)
-        return "<{}('{}') from IBMProvider({})>".format(
-            self.__class__.__name__, self.name(), credentials_info)
+        return "<{}('{}')>".format(self.__class__.__name__, self.name())
 
     def _deprecate_id_instruction(
             self,
@@ -778,7 +772,7 @@ class IBMRetiredBackend(IBMBackend):
 
         Args:
             configuration: Backend configuration.
-            provider: IBM Quantum account provider
+            provider: IBM Quantum account provider.
             credentials: IBM Quantum credentials.
             api_client: IBM Quantum client used to communicate with the server.
         """

--- a/qiskit_ibm/ibm_provider.py
+++ b/qiskit_ibm/ibm_provider.py
@@ -20,22 +20,22 @@ import copy
 import os
 
 from qiskit.providers import ProviderV1 as Provider  # type: ignore[attr-defined]
-from qiskit.providers.models import (QasmBackendConfiguration,
-                                     PulseBackendConfiguration)
 from qiskit.circuit import QuantumCircuit
+from qiskit.providers.backend import BackendV1 as Backend
+from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from qiskit.transpiler import Layout
 
 from qiskit_ibm.runtime import runtime_job  # pylint: disable=unused-import
 
-from .api.clients import AuthClient, AccountClient, VersionClient
+from .api.clients import AuthClient, VersionClient
 from .apiconstants import QISKIT_IBM_API_URL
-from .ibm_backend import IBMBackend, IBMSimulator  # pylint: disable=cyclic-import
-from .credentials import Credentials, HubGroupProject, discover_credentials
+from .ibm_backend import IBMBackend  # pylint: disable=cyclic-import
+from .credentials import Credentials, HubGroupProjectID, discover_credentials
 from .credentials.configrc import (remove_credentials, read_credentials_from_qiskitrc,
                                    store_credentials)
-from .credentials.exceptions import HubGroupProjectInvalidStateError
+from .credentials.exceptions import HubGroupProjectIDInvalidStateError
+from .hub_group_project import HubGroupProject  # pylint: disable=cyclic-import
 from .ibm_backend_service import IBMBackendService  # pylint: disable=cyclic-import
-from .utils.json_decoder import decode_backend_configuration
 from .random.ibm_random_service import IBMRandomService  # pylint: disable=cyclic-import
 from .experiment import IBMExperimentService  # pylint: disable=cyclic-import
 from .runtime.ibm_runtime_service import IBMRuntimeService  # pylint: disable=cyclic-import
@@ -58,19 +58,12 @@ class IBMProvider(Provider):
         from qiskit_ibm import IBMProvider
         IBMProvider.save_account(token=<INSERT_IBM_QUANTUM_TOKEN>)
 
-    The open access provider (`ibm-q/open/main`) is the default provider, but you can overwrite
-    this default using the `hub`, `group`, and `project` keywords in `save_account()`.
-    Once credentials are saved you can simply instantiate the provider like below to load the
-    saved account and default provider::
+    You can set the default project using the `hub`, `group`, and `project` keywords
+    in `save_account()`. Once credentials are saved you can simply instantiate the
+    provider like below to load the saved account and default project::
 
         from qiskit_ibm import IBMProvider
         provider = IBMProvider()
-
-    To access a different provider, specify the hub, group and project name of the
-    desired provider during instantiation::
-
-        from qiskit_ibm import IBMProvider
-        provider = IBMProvider(hub='ibm-q', group='test', project='default')
 
     Instead of saving credentials to disk, you can also set the environment
     variables QISKIT_IBM_API_TOKEN, QISKIT_IBM_API_URL, QISKIT_IBM_HUB, QISKIT_IBM_GROUP
@@ -80,25 +73,23 @@ class IBMProvider(Provider):
         provider = IBMProvider()
 
     You can also enable an account just for the current session by instantiating
-    the provider with the API token and optionally a hub/group/project::
+    the provider with the API token::
 
         from qiskit_ibm import IBMProvider
         provider = IBMProvider(token=<INSERT_IBM_QUANTUM_TOKEN>)
 
     `token` is the only required attribute that needs to be set using one of the above methods.
     If no `url` is set, it defaults to 'https://auth.quantum-computing.ibm.com/api'.
-    If no `hub`, `group` and `project` is set, it defaults to the open provider. (ibm-q/open/main)
 
-    Each provider may offer different services. The main service,
-    :class:`~qiskit_ibm.ibm_backend_service.IBMBackendService`, is
-    available to all providers and gives access to IBM Quantum
+    The IBMProvider offers different services. The main service,
+    :class:`~qiskit_ibm.ibm_backend_service.IBMBackendService` gives access to IBM Quantum
     devices and simulators.
 
     You can obtain an instance of a service using the :meth:`service()` method
     or as an attribute of this ``IBMProvider`` instance. For example::
 
         backend_service = provider.service('backend')
-        backend_service = provider.service.backend
+        backend_service = provider.backend
 
     Since :class:`~qiskit_ibm.ibm_backend_service.IBMBackendService`
     is the main service, some of the backend-related methods are available
@@ -121,108 +112,75 @@ class IBMProvider(Provider):
 
     Note:
         The ``backend`` attribute can be used to autocomplete the names of
-        backends available to this provider. To autocomplete, press ``tab``
+        backends available to this account. To autocomplete, press ``tab``
         after ``provider.backend.``. This feature may not be available
         if an error occurs during backend discovery. Also note that
         this feature is only available in interactive sessions, such as
         in Jupyter Notebook and the Python interpreter.
     """
 
-    _credentials: Credentials = None
-    """Contains credentials of a new IBMProvider being initialized. If None, all the
-    provider instances have already been initialized and __new__ should return an
-    existing instance."""
-
-    _providers: Dict[HubGroupProject, 'IBMProvider'] = OrderedDict()
-
-    def __new__(
-            cls,
+    def __init__(
+            self,
             token: Optional[str] = None,
             url: Optional[str] = None,
-            hub: Optional[str] = None,
-            group: Optional[str] = None,
-            project: Optional[str] = None,
             **kwargs: Any
-    ) -> 'IBMProvider':
+    ) -> None:
         """IBMProvider constructor
 
         Args:
             token: IBM Quantum token.
             url: URL for the IBM Quantum authentication server.
-            hub: Name of the hub to use.
-            group: Name of the group to use.
-            project: Name of the project to use.
             **kwargs: Additional settings for the connection:
 
                 * proxies (dict): proxy configuration.
                 * verify (bool): verify the server's TLS certificate.
 
         Returns:
-            If `hub`, `group`, and `project` are specified, the corresponding provider
-            is returned. Otherwise the default provider is looked up in the
-            following order and returned:
-
-                * environment variables (QISKIT_IBM_HUB, QISKIT_IBM_GROUP and QISKIT_IBM_PROJECT)
-                * default_provider (hub/group/project) saved to disk
-                * open access provider (ibmq/open/main)
+            An instance of IBMProvider with services like :class:`~qiskit_ibm.IBMBackendService`,
+            :class:`~qiskit_ibm.runtime.IBMRuntimeService`,
+            :class:`~qiskit_ibm.experiment.IBMExperimentService` and
+            :class:`~qiskit_ibm.random.IBMRandomService`
+            as available to the account.
 
         Raises:
-            IBMProviderCredentialsInvalidFormat: If the default provider saved on
+            IBMProviderCredentialsInvalidFormat: If the default hub/group/project saved on
                 disk could not be parsed.
-            IBMProviderCredentialsNotFound: If no IBM Quantum credentials
-                can be found.
+            IBMProviderCredentialsNotFound: If no IBM Quantum credentials can be found.
             IBMProviderCredentialsInvalidUrl: If the URL specified is not
                 a valid IBM Quantum authentication URL.
-            IBMProviderCredentialsInvalidToken: If the `token` is not a valid
-                IBM Quantum token.
+            IBMProviderCredentialsInvalidToken: If the `token` is not a valid IBM Quantum token.
         """
-        account_credentials, account_preferences, hgp = cls._resolve_credentials(
+        # pylint: disable=unused-argument,unsubscriptable-object
+        super().__init__()
+        account_credentials, account_preferences = self._resolve_credentials(
             token=token,
             url=url,
-            hub=hub,
-            group=group,
-            project=project,
             **kwargs
         )
-        hub, group, project = hgp.to_tuple()
-        if not cls._credentials and (not cls._providers or
-                                     cls._is_different_account(account_credentials.token)):
-            cls._initialize_providers(credentials=account_credentials,
-                                      preferences=account_preferences)
-            return cls._get_provider(hub=hub, group=group, project=project)
-        elif not cls._credentials and cls._providers:
-            return cls._get_provider(hub=hub, group=group, project=project)
-        else:
-            return object.__new__(cls)
+        self._initialize_hgps(credentials=account_credentials, preferences=account_preferences)
+        self._initialize_services()
 
-    @classmethod
     def _resolve_credentials(
-            cls,
+            self,
             token: Optional[str] = None,
             url: Optional[str] = None,
-            hub: Optional[str] = None,
-            group: Optional[str] = None,
-            project: Optional[str] = None,
             **kwargs: Any
-    ) -> Tuple[Credentials, Dict, HubGroupProject]:
+    ) -> Tuple[Credentials, Dict]:
         """Resolve credentials after looking up env variables and credentials saved on disk
 
         Args:
             token: IBM Quantum token.
             url: URL for the IBM Quantum authentication server.
-            hub: Name of the hub to use.
-            group: Name of the group to use.
-            project: Name of the project to use.
             **kwargs: Additional settings for the connection:
 
                 * proxies (dict): proxy configuration.
                 * verify (bool): verify the server's TLS certificate.
 
         Returns:
-            Tuple of account_credentials, preferences, hub, group and project
+            Tuple of account_credentials, preferences
 
         Raises:
-            IBMProviderCredentialsInvalidFormat: If the default provider saved on
+            IBMProviderCredentialsInvalidFormat: If the default hub/group/project saved on
                 disk could not be parsed.
             IBMProviderCredentialsNotFound: If no IBM Quantum credentials can be found.
             IBMProviderCredentialsInvalidToken: If the `token` is not a valid IBM Quantum token.
@@ -235,14 +193,14 @@ class IBMProvider(Provider):
                     'found: "{}" of type {}.'.format(token, type(token)))
             url = url or os.getenv('QISKIT_IBM_API_URL') or QISKIT_IBM_API_URL
             account_credentials = Credentials(token=token, url=url, auth_url=url, **kwargs)
-            preferences = {}  # type: Optional[Dict]
+            preferences: Optional[Dict] = {}
         else:
             # Check for valid credentials in env variables or qiskitrc file.
             try:
                 saved_credentials, preferences = discover_credentials()
-            except HubGroupProjectInvalidStateError as ex:
+            except HubGroupProjectIDInvalidStateError as ex:
                 raise IBMProviderCredentialsInvalidFormat(
-                    'Invalid provider (hub/group/project) data found {}'
+                    'Invalid hub/group/project data found {}'
                     .format(str(ex))) from ex
             credentials_list = list(saved_credentials.values())
             if not credentials_list:
@@ -252,32 +210,14 @@ class IBMProvider(Provider):
                 raise IBMProviderMultipleCredentialsFound(
                     'Multiple IBM Quantum Experience credentials found.')
             account_credentials = credentials_list[0]
-            if not any([hub, group, project]) and account_credentials.default_provider:
-                hub, group, project = account_credentials.default_provider.to_tuple()
-        hgp = HubGroupProject(hub=hub, group=group, project=project)
-        return account_credentials, preferences, hgp
+        return account_credentials, preferences
 
-    @classmethod
-    def _is_different_account(cls, token: str) -> bool:
-        """Check if token is different from already instantiated account.
-
-        Args:
-            token: IBM Quantum token.
-
-        Returns:
-            ``True`` if token passed is different from already instantiated account,
-            ``False`` otherwise
-        """
-        first_provider = list(cls._providers.values())[0]
-        return token != first_provider.credentials.token
-
-    @classmethod
-    def _initialize_providers(
-            cls,
+    def _initialize_hgps(
+            self,
             credentials: Credentials,
             preferences: Optional[Dict] = None
     ) -> None:
-        """Authenticate against IBM Quantum and populate the providers.
+        """Authenticate against IBM Quantum and populate the hub/group/projects.
 
         Args:
             credentials: Credentials for IBM Quantum.
@@ -286,27 +226,26 @@ class IBMProvider(Provider):
         Raises:
             IBMProviderCredentialsInvalidUrl: If the URL specified is not
                 a valid IBM Quantum authentication URL.
+            IBMProviderError: If no hub/group/project could be found for this account.
         """
-        version_info = cls._check_api_version(credentials)
+        self._hgps: Dict[HubGroupProjectID, HubGroupProject] = OrderedDict()
+        version_info = self._check_api_version(credentials)
         # Check the URL is a valid authentication URL.
         if not version_info['new_api'] or 'api-auth' not in version_info:
             raise IBMProviderCredentialsInvalidUrl(
                 'The URL specified ({}) is not an IBM Quantum authentication URL. '
                 'Valid authentication URL: {}.'
                 .format(credentials.url, QISKIT_IBM_API_URL))
-        if cls._providers:
-            logger.warning('Credentials are already in use. The existing '
-                           'account in the session will be replaced.')
-            cls._disable_account()
         auth_client = AuthClient(credentials.token,
                                  credentials.base_url,
                                  **credentials.connection_parameters())
         service_urls = auth_client.current_service_urls()
         user_hubs = auth_client.user_hubs()
         preferences = preferences or {}
+        is_open = True  # First hgp is open access
         for hub_info in user_hubs:
             # Build credentials.
-            provider_credentials = Credentials(
+            hgp_credentials = Credentials(
                 credentials.token,
                 access_token=auth_client.current_access_token(),
                 url=service_urls['http'],
@@ -318,21 +257,28 @@ class IBMProvider(Provider):
                 default_provider=credentials.default_provider,
                 **hub_info
             )
-            provider_credentials.preferences = \
-                preferences.get(provider_credentials.unique_id(), {})
-            # _credentials class variable is read in __init__ to set provider credentials
-            cls._credentials = provider_credentials
-            # Build the provider.
+            hgp_credentials.preferences = \
+                preferences.get(hgp_credentials.unique_id(), {})
+            # Build the hgp.
             try:
-                provider = IBMProvider(token=credentials.token, **hub_info)
-                cls._providers[provider.credentials.unique_id()] = provider
-                # Clear _credentials class variable so __init__ is not processed for the first
-                # call to __new__ (since all IBMProvider instances are initialized by this method)
-                cls._credentials = None
+                hgp = HubGroupProject(credentials=hgp_credentials, provider=self, is_open=is_open)
+                self._hgps[hgp.credentials.unique_id()] = hgp
+                is_open = False  # hgps after first are premium and not open access
             except Exception:  # pylint: disable=broad-except
-                # Catch-all for errors instantiating the provider.
-                logger.warning('Unable to instantiate provider for %s: %s',
+                # Catch-all for errors instantiating the hgp.
+                logger.warning('Unable to instantiate hub/group/project for %s: %s',
                                hub_info, traceback.format_exc())
+        if not self._hgps:
+            raise IBMProviderError('No hub/group/project could be found for this account.')
+        # Move open hgp to end of the list
+        if len(self._hgps) > 1:
+            open_hgp = self._get_hgp()
+            self._hgps.move_to_end(open_hgp.credentials.unique_id())
+        if credentials.default_provider:
+            # Move user selected hgp to front of the list
+            hub, group, project = credentials.default_provider.to_tuple()
+            default_hgp = self._get_hgp(hub=hub, group=group, project=project)
+            self._hgps.move_to_end(default_hgp.credentials.unique_id(), last=False)
 
     @staticmethod
     def _check_api_version(credentials: Credentials) -> Dict[str, Union[bool, str]]:
@@ -348,26 +294,13 @@ class IBMProvider(Provider):
                                        **credentials.connection_parameters())
         return version_finder.version()
 
-    @classmethod
-    def _disable_account(cls) -> None:
-        """Disable the account currently in use for the session.
-
-        Raises:
-            IBMProviderCredentialsNotFound: If no account is in use for the session.
-        """
-        if not cls._providers:
-            raise IBMProviderCredentialsNotFound(
-                'No IBM Quantum account is in use for the session.')
-        cls._providers = OrderedDict()
-
-    @classmethod
-    def _get_provider(
-            cls,
+    def _get_hgp(
+            self,
             hub: Optional[str] = None,
             group: Optional[str] = None,
             project: Optional[str] = None,
-    ) -> 'IBMProvider':
-        """Return a provider for a single hub/group/project combination.
+    ) -> HubGroupProject:
+        """Return an instance of `HubGroupProject` for a single hub/group/project combination.
 
         Args:
             hub: Name of the hub.
@@ -375,114 +308,82 @@ class IBMProvider(Provider):
             project: Name of the project.
 
         Returns:
-            A provider that matches the specified criteria or default provider.
+            An instance of `HubGroupProject` that matches the specified criteria or the default.
 
         Raises:
-            IBMProviderError: If no provider matches the specified criteria,
-                if more than one provider matches the specified criteria or if
-                no provider could be found for this account.
+            IBMProviderError: If no hub/group/project matches the specified criteria,
+                if more than one hub/group/project matches the specified criteria or if
+                no hub/group/project could be found for this account.
         """
-        providers = cls._get_providers(hub=hub, group=group, project=project)
+        hgps = self._get_hgps(hub=hub, group=group, project=project)
         if any([hub, group, project]):
-            if not providers:
-                raise IBMProviderError('No provider matches the specified criteria: '
+            if not hgps:
+                raise IBMProviderError('No hub/group/project matches the specified criteria: '
                                        'hub = {}, group = {}, project = {}'
                                        .format(hub, group, project))
-            if len(providers) > 1:
-                raise IBMProviderError('More than one provider matches the specified criteria.'
-                                       'hub = {}, group = {}, project = {}'
+            if len(hgps) > 1:
+                raise IBMProviderError('More than one hub/group/project matches the '
+                                       'specified criteria. hub = {}, group = {}, project = {}'
                                        .format(hub, group, project))
-        elif not providers:
-            # Prevent edge case where no providers are available.
-            raise IBMProviderError('No Hub/Group/Project could be found for this account.')
-        return providers[0]
+        elif not hgps:
+            # Prevent edge case where no hub/group/project is available.
+            raise IBMProviderError('No hub/group/project could be found for this account.')
+        return hgps[0]
 
-    def __init__(
+    def _get_hgps(
             self,
-            token: Optional[str] = None,
-            url: Optional[str] = None,
             hub: Optional[str] = None,
             group: Optional[str] = None,
             project: Optional[str] = None,
-            **kwargs: Any
-    ) -> None:
-        # pylint: disable=unused-argument,unsubscriptable-object
-        super().__init__()
-        if self._credentials:
-            self.credentials = self._credentials
-            self._api_client = AccountClient(self.credentials,
-                                             **self.credentials.connection_parameters())
-            # Initialize the internal list of backends.
-            self.__backends: Dict[str, IBMBackend] = {}
-            self._backend = IBMBackendService(self)
+    ) -> List[HubGroupProject]:
+        """Return a list of `HubGroupProject` instances, subject to optional filtering.
+
+        Args:
+            hub: Name of the hub.
+            group: Name of the group.
+            project: Name of the project.
+
+        Returns:
+            A list of `HubGroupProject` instances that match the specified criteria.
+        """
+        filters: List[Callable[[HubGroupProjectID], bool]] = []
+        if hub:
+            filters.append(lambda hgp: hgp.hub == hub)
+        if group:
+            filters.append(lambda hgp: hgp.group == group)
+        if project:
+            filters.append(lambda hgp: hgp.project == project)
+        hgps = [hgp for key, hgp in self._hgps.items()
+                if all(f(key) for f in filters)]
+        return hgps
+
+    def _initialize_services(self) -> None:
+        """Initialize all services."""
+        self._backend = None
+        self._experiment = None
+        self._random = None
+        self._runtime = None
+        hgps = self._get_hgps()
+        for hgp in hgps:
+            # Initialize backend service
+            if not self._backend:
+                self._backend = IBMBackendService(self, hgp)
             # Initialize other services.
-            self._random = IBMRandomService(self) if self.credentials.extractor_url else None
-            self._experiment = IBMExperimentService(self) \
-                if self.credentials.experiment_url else None
-            self._runtime = IBMRuntimeService(self) \
-                if self.credentials.runtime_url else None
-            self._services = {'backend': self._backend,
-                              'random': self._random,
-                              'experiment': self._experiment,
-                              'runtime': self._runtime}
-
-    @property
-    def _backends(self) -> Dict[str, IBMBackend]:
-        """Gets the backends for the provider, if not loaded.
-
-        Returns:
-            Dict[str, IBMBackend]: the backends
-        """
-        if not self.__backends:
-            self.__backends = self._discover_remote_backends()
-        return self.__backends
-
-    @_backends.setter
-    def _backends(self, value: Dict[str, IBMBackend]) -> None:
-        """Sets the value for the account's backends.
-
-        Args:
-            value: the backends
-        """
-        self.__backends = value
-
-    def _discover_remote_backends(self, timeout: Optional[float] = None) -> Dict[str, IBMBackend]:
-        """Return the remote backends available for this provider.
-
-        Args:
-            timeout: Maximum number of seconds to wait for the discovery of
-                remote backends.
-
-        Returns:
-            A dict of the remote backend instances, keyed by backend name.
-        """
-        ret = OrderedDict()  # type: ignore[var-annotated]
-        configs_list = self._api_client.list_backends(timeout=timeout)
-        for raw_config in configs_list:
-            # Make sure the raw_config is of proper type
-            if not isinstance(raw_config, dict):
-                logger.warning("An error occurred when retrieving backend "
-                               "information. Some backends might not be available.")
-                continue
-            try:
-                decode_backend_configuration(raw_config)
-                try:
-                    config = PulseBackendConfiguration.from_dict(raw_config)
-                except (KeyError, TypeError):
-                    config = QasmBackendConfiguration.from_dict(raw_config)
-                backend_cls = IBMSimulator if config.simulator else IBMBackend
-                ret[config.backend_name] = backend_cls(
-                    configuration=config,
-                    provider=self,
-                    credentials=self.credentials,
-                    api_client=self._api_client)
-            except Exception:  # pylint: disable=broad-except
-                logger.warning(
-                    'Remote backend "%s" for provider %s could not be instantiated due to an '
-                    'invalid config: %s',
-                    raw_config.get('backend_name', raw_config.get('name', 'unknown')),
-                    repr(self), traceback.format_exc())
-        return ret
+            if not self._experiment:
+                self._experiment = IBMExperimentService(self, hgp) \
+                    if hgp.has_service('experiment') else None
+            if not self._random:
+                self._random = IBMRandomService(self, hgp) \
+                    if hgp.has_service('random') else None
+            if not self._runtime:
+                self._runtime = IBMRuntimeService(self, hgp) \
+                    if hgp.has_service('runtime') else None
+            if all([self._backend, self._experiment, self._random, self._runtime]):
+                break
+        self._services = {'backend': self._backend,
+                          'random': self._random,
+                          'experiment': self._experiment,
+                          'runtime': self._runtime}
 
     @property
     def backend(self) -> IBMBackendService:
@@ -540,88 +441,20 @@ class IBMProvider(Provider):
         else:
             raise IBMNotAuthorizedError("You are not authorized to use the runtime service.")
 
-    @classmethod
-    def active_account(cls) -> Optional[Dict[str, str]]:
+    def active_account(self) -> Optional[Dict[str, str]]:
         """Return the IBM Quantum account currently in use for the session.
 
         Returns:
             A dictionary with information about the account currently in the session,
                 None if there is no active account in session
         """
-        if not cls._providers:
+        if not self._hgps:
             return None
-        first_provider = list(cls._providers.values())[0]
+        first_hgp = self._get_hgp()
         return {
-            'token': first_provider.credentials.token,
-            'url': first_provider.credentials.auth_url
+            'token': first_hgp.credentials.token,
+            'url': first_hgp.credentials.auth_url
         }
-
-    @classmethod
-    def providers(
-            cls,
-            token: Optional[str] = None,
-            url: Optional[str] = None,
-            hub: Optional[str] = None,
-            group: Optional[str] = None,
-            project: Optional[str] = None,
-            **kwargs: Any
-    ) -> List['IBMProvider']:
-        """Initialize account and return a list of providers.
-
-        Args:
-            token: IBM Quantum token.
-            url: URL for the IBM Quantum authentication server.
-            hub: Name of the hub.
-            group: Name of the group.
-            project: Name of the project.
-            **kwargs: Additional settings for the connection:
-
-                * proxies (dict): proxy configuration.
-                * verify (bool): verify the server's TLS certificate.
-
-        Returns:
-            A list of providers that match the specified criteria.
-        """
-        account_credentials, account_preferences, *_ = cls._resolve_credentials(
-            token=token,
-            url=url,
-            hub=hub,
-            group=group,
-            project=project,
-            **kwargs
-        )
-        if not cls._providers or cls._is_different_account(account_credentials.token):
-            cls._initialize_providers(credentials=account_credentials,
-                                      preferences=account_preferences)
-        return cls._get_providers(hub=hub, group=group, project=project)
-
-    @classmethod
-    def _get_providers(
-            cls,
-            hub: Optional[str] = None,
-            group: Optional[str] = None,
-            project: Optional[str] = None,
-    ) -> List['IBMProvider']:
-        """Return a list of providers, subject to optional filtering.
-
-        Args:
-            hub: Name of the hub.
-            group: Name of the group.
-            project: Name of the project.
-
-        Returns:
-            A list of providers that match the specified criteria.
-        """
-        filters = []  # type: List[Callable[[HubGroupProject], bool]]
-        if hub:
-            filters.append(lambda hgp: hgp.hub == hub)
-        if group:
-            filters.append(lambda hgp: hgp.group == group)
-        if project:
-            filters.append(lambda hgp: hgp.project == project)
-        providers = [provider for key, provider in cls._providers.items()
-                     if all(f(key) for f in filters)]
-        return providers
 
     @staticmethod
     def delete_account() -> None:
@@ -656,15 +489,15 @@ class IBMProvider(Provider):
         """Save the account to disk for future use.
 
         Note:
-            If storing a default provider to disk, all three parameters
+            If storing a default hub/group/project to disk, all three parameters
             `hub`, `group`, `project` must be specified.
 
         Args:
             token: IBM Quantum token.
             url: URL for the IBM Quantum authentication server.
-            hub: Name of the hub for the default provider to store on disk.
-            group: Name of the group for the default provider to store on disk.
-            project: Name of the project for the default provider to store on disk.
+            hub: Name of the hub.
+            group: Name of the group.
+            project: Name of the project.
             overwrite: Overwrite existing credentials.
             **kwargs:
                 * proxies (dict): Proxy configuration for the server.
@@ -688,16 +521,14 @@ class IBMProvider(Provider):
         # If any `hub`, `group`, or `project` is specified, make sure all parameters are set.
         if any([hub, group, project]) and not all([hub, group, project]):
             raise IBMProviderValueError('The hub, group, and project parameters must all be '
-                                        'specified when storing a default provider to disk: '
-                                        'hub = "{}", group = "{}", project = "{}"'
+                                        'specified when storing a default hub/group/project to '
+                                        'disk: hub = "{}", group = "{}", project = "{}"'
                                         .format(hub, group, project))
-        # If specified, get the provider to store.
-        default_provider_hgp = HubGroupProject(hub, group, project) \
+        # If specified, get the hub/group/project to store.
+        default_hgp_id = HubGroupProjectID(hub, group, project) \
             if all([hub, group, project]) else None
-        credentials = Credentials(token=token, url=url,
-                                  default_provider=default_provider_hgp, **kwargs)
-        store_credentials(credentials,
-                          overwrite=overwrite)
+        credentials = Credentials(token=token, url=url, default_provider=default_hgp_id, **kwargs)
+        store_credentials(credentials, overwrite=overwrite)
 
     @staticmethod
     def saved_account() -> Dict[str, str]:
@@ -728,9 +559,12 @@ class IBMProvider(Provider):
             filters: Optional[Callable[[List[IBMBackend]], bool]] = None,
             min_num_qubits: Optional[int] = None,
             input_allowed: Optional[Union[str, List[str]]] = None,
+            hub: Optional[str] = None,
+            group: Optional[str] = None,
+            project: Optional[str] = None,
             **kwargs: Any
     ) -> List[IBMBackend]:
-        """Return all backends accessible via this provider, subject to optional filtering.
+        """Return all backends accessible via this account, subject to optional filtering.
 
         Args:
             name: Backend name to filter by.
@@ -744,6 +578,9 @@ class IBMProvider(Provider):
                 For example, ``inputs_allowed='runtime'`` will return all backends
                 that support Qiskit Runtime. If a list is given, the backend must
                 support all types specified in the list.
+            hub: Name of the hub.
+            group: Name of the group.
+            project: Name of the project.
             kwargs: Simple filters that specify a ``True``/``False`` criteria in the
                 backend configuration, backends status, or provider credentials.
                 An example to get the operational backends with 5 qubits::
@@ -755,16 +592,57 @@ class IBMProvider(Provider):
         """
         # pylint: disable=arguments-differ
         return self._backend.backends(name=name, filters=filters, min_num_qubits=min_num_qubits,
-                                      input_allowed=input_allowed, **kwargs)
+                                      input_allowed=input_allowed, hub=hub, group=group,
+                                      project=project, **kwargs)
+
+    def get_backend(
+            self,
+            name: str = None,
+            hub: Optional[str] = None,
+            group: Optional[str] = None,
+            project: Optional[str] = None,
+            **kwargs: Any
+    ) -> Backend:
+        """Return a single backend matching the specified filtering.
+
+        Args:
+            name (str): name of the backend.
+            hub: Name of the hub.
+            group: Name of the group.
+            project: Name of the project.
+            **kwargs: dict used for filtering.
+
+        Returns:
+            Backend: a backend matching the filtering.
+
+        Raises:
+            QiskitBackendNotFoundError: if no backend could be found or
+                more than one backend matches the filtering criteria.
+            IBMProviderValueError: If only one or two parameters from `hub`, `group`,
+                `project` are specified.
+        """
+        # pylint: disable=arguments-differ
+        # If any `hub`, `group`, or `project` is specified, make sure all parameters are set.
+        if any([hub, group, project]) and not all([hub, group, project]):
+            raise IBMProviderValueError('The hub, group, and project parameters must all be '
+                                        'specified. '
+                                        'hub = "{}", group = "{}", project = "{}"'
+                                        .format(hub, group, project))
+        backends = self.backends(name, hub=hub, group=group, project=project, **kwargs)
+        if len(backends) > 1:
+            raise QiskitBackendNotFoundError("More than one backend matches the criteria")
+        if not backends:
+            raise QiskitBackendNotFoundError("No backend matches the criteria")
+        return backends[0]
 
     def has_service(self, name: str) -> bool:
-        """Check if this provider has access to the service.
+        """Check if this account has access to the service.
 
         Args:
             name: Name of the service.
 
         Returns:
-            Whether the provider has access to the service.
+            Whether the account has access to the service.
 
         Raises:
             IBMInputValueError: If an unknown service name is specified.
@@ -791,6 +669,9 @@ class IBMProvider(Provider):
             transpiler_options: Optional[dict] = None,
             measurement_error_mitigation: bool = False,
             use_measure_esp: Optional[bool] = None,
+            hub: Optional[str] = None,
+            group: Optional[str] = None,
+            project: Optional[str] = None,
             **run_config: Dict
     ) -> 'runtime_job.RuntimeJob':
         """Execute the input circuit(s) on a backend using the runtime service.
@@ -844,6 +725,12 @@ class IBMProvider(Provider):
                 than standard measurement sequences. See
                 `here <https://arxiv.org/pdf/2008.08571.pdf>`_.
 
+            hub: Name of the hub.
+
+            group: Name of the group.
+
+            project: Name of the project.
+
             **run_config: Extra arguments used to configure the circuit execution.
 
         Returns:
@@ -874,7 +761,8 @@ class IBMProvider(Provider):
             inputs['use_measure_esp'] = use_measure_esp
         options = {'backend_name': backend_name}
         return self.runtime.run('circuit-runner', options=options, inputs=inputs,
-                                result_decoder=RunnerResult)
+                                result_decoder=RunnerResult,
+                                hub=hub, group=group, project=project)
 
     def service(self, name: str) -> Any:
         """Return the specified service.
@@ -900,19 +788,21 @@ class IBMProvider(Provider):
         """Return all available services.
 
         Returns:
-            All services available to this provider.
+            All services available to this account.
         """
         return {key: val for key, val in self._services.items() if val is not None}
 
-    def __eq__(
+    def _get_hgp_by_service_and_backend_name(
             self,
-            other: Any
-    ) -> bool:
-        if not isinstance(other, IBMProvider):
-            return False
-        return self.credentials == other.credentials
+            service_name: str,
+            backend_name: str
+    ) -> HubGroupProject:
+        hgps = self._get_hgps()
+        for hgp in hgps:
+            if hgp.has_service(service_name) and \
+                    hgp.get_backend(backend_name):
+                return hgp
+        raise IBMNotAuthorizedError(f"You are not authorized to use {service_name} service.")
 
     def __repr__(self) -> str:
-        credentials_info = "hub='{}', group='{}', project='{}'".format(
-            self.credentials.hub, self.credentials.group, self.credentials.project)
-        return "<{}({})>".format(self.__class__.__name__, credentials_info)
+        return "<{}>".format(self.__class__.__name__)

--- a/qiskit_ibm/ibm_provider.py
+++ b/qiskit_ibm/ibm_provider.py
@@ -81,6 +81,18 @@ class IBMProvider(Provider):
     `token` is the only required attribute that needs to be set using one of the above methods.
     If no `url` is set, it defaults to 'https://auth.quantum-computing.ibm.com/api'.
 
+    Note:
+        The hub/group/project is selected based on the below selection order,
+        in decreasing order of priority.
+
+        * The hub/group/project you explicity specify when calling a service.
+          Ex: `provider.get_backend()`, `provider.runtime.run()`,
+          `provider.experiment.create_experiment()`, etc.
+        * The hub/group/project required for the service.
+        * The default hub/group/project you set using `save_account()`.
+        * A premium hub/group/project in your account.
+        * An open access hub/group/project.
+
     The IBMProvider offers different services. The main service,
     :class:`~qiskit_ibm.ibm_backend_service.IBMBackendService` gives access to IBM Quantum
     devices and simulators.

--- a/qiskit_ibm/random/ibm_random_service.py
+++ b/qiskit_ibm/random/ibm_random_service.py
@@ -21,6 +21,7 @@ from .cqcextractor import CQCExtractor
 from ..api.clients.random import RandomClient
 from ..api.exceptions import RequestsApiError
 from ..exceptions import IBMError
+from ..hub_group_project import HubGroupProject
 
 logger = logging.getLogger(__name__)
 
@@ -39,15 +40,17 @@ class IBMRandomService:
         extractor = provider.random.cqc_extractor  # Short hand for above.
     """
 
-    def __init__(self, provider: 'ibm_provider.IBMProvider') -> None:
+    def __init__(self, provider: 'ibm_provider.IBMProvider', hgp: HubGroupProject) -> None:
         """IBMRandomService constructor.
 
         Args:
             provider: IBM Quantum account provider.
+            hgp: default hub/group/project to use for the service.
         """
         self._provider = provider
-        if provider.credentials.extractor_url:
-            self._random_client = RandomClient(provider.credentials)
+        self._hgp = hgp
+        if hgp.credentials.extractor_url:
+            self._random_client = RandomClient(hgp.credentials)
             self._initialized = False
         else:
             self._random_client = None

--- a/qiskit_ibm/random/ibm_random_service.py
+++ b/qiskit_ibm/random/ibm_random_service.py
@@ -48,7 +48,7 @@ class IBMRandomService:
             hgp: default hub/group/project to use for the service.
         """
         self._provider = provider
-        self._hgp = hgp
+        self._default_hgp = hgp
         if hgp.credentials.extractor_url:
             self._random_client = RandomClient(hgp.credentials)
             self._initialized = False

--- a/test/contextmanagers.py
+++ b/test/contextmanagers.py
@@ -12,7 +12,6 @@
 
 """Context managers for using with IBM Provider unit tests."""
 
-from collections import OrderedDict
 import os
 from typing import Optional, Dict
 from contextlib import ContextDecorator, contextmanager
@@ -22,7 +21,6 @@ from unittest.mock import patch
 from qiskit_ibm.credentials import configrc, Credentials
 from qiskit_ibm.credentials.environ import VARIABLES_MAP
 from qiskit_ibm import IBMProvider
-from qiskit_ibm.credentials import HubGroupProject
 
 CREDENTIAL_ENV_VARS = VARIABLES_MAP.keys()
 
@@ -118,51 +116,30 @@ class no_file(ContextDecorator):
         return self.isfile_original(filename_)
 
 
-class MockIBMProvider:
-    """Mock class for IBM Provider"""
-
-    @classmethod
-    def _mock_initialize_provider(
-            cls,
-            credentials: Credentials,
-            preferences: Optional[Dict] = None
-    ) -> None:
-        """Mock ``_initialize_provider()``, just storing the credentials."""
-        cls._providers = OrderedDict()
-        provider = dict()
-        provider['credentials'] = credentials
-        cls._providers[HubGroupProject('ibm-q', 'open', 'main')] = provider
-        if preferences:
-            credentials.preferences = preferences.get(credentials.unique_id(), {})
-
-    @classmethod
-    def _mock_get_provider(
-            cls,
-            token: Optional[str] = None,
-            url: Optional[str] = None,
-            hub: Optional[str] = None,
-            group: Optional[str] = None,
-            project: Optional[str] = None
-    ):
-        # pylint: disable=unused-argument
-        return cls._providers[HubGroupProject('ibm-q', 'open', 'main')]
+def _mock_initialize_hgps(
+        self,
+        credentials: Credentials,
+        preferences: Optional[Dict] = None
+) -> None:
+    """Mock ``_initialize_hgps()``, just storing the credentials."""
+    hgp = dict()
+    hgp['credentials'] = credentials
+    self._hgp = hgp
+    self._hgps = {}
+    if preferences:
+        credentials.preferences = preferences.get(credentials.unique_id(), {})
 
 
 @contextmanager
 def mock_ibm_provider():
     """Mock the initialization of ``IBMProvider``, so it does not query the API."""
-    patcher = patch.object(IBMProvider, '_initialize_providers',
-                           side_effect=MockIBMProvider._mock_initialize_provider,
+    patcher = patch.object(IBMProvider, '_initialize_hgps',
+                           side_effect=_mock_initialize_hgps,
                            autospec=True)
     patcher2 = patch.object(IBMProvider, '_check_api_version',
                             return_value={'new_api': True, 'api-auth': '0.1'})
-    patcher3 = patch.object(IBMProvider, '_get_provider',
-                            side_effect=MockIBMProvider._mock_get_provider,
-                            autospec=True)
     patcher.start()
     patcher2.start()
-    patcher3.start()
     yield
-    patcher3.stop()
     patcher2.stop()
     patcher.stop()

--- a/test/ibm/experiment/test_experiment.py
+++ b/test/ibm/experiment/test_experiment.py
@@ -26,21 +26,19 @@ class TestExperimentPreferences(IBMTestCase):
     """Test experiment preferences."""
 
     @classmethod
-    def setUpClass(cls):
+    @requires_provider
+    def setUpClass(cls, provider, hub, group, project):
         """Initial class level setup."""
         # pylint: disable=arguments-differ
         super().setUpClass()
-        cls.provider = cls._setup_provider()  # pylint: disable=no-value-for-parameter
+        cls.provider = provider
+        cls.hub = hub
+        cls.group = group
+        cls.project = project
         try:
             cls.service = cls.provider.service('experiment')
         except IBMNotAuthorizedError:
             raise SkipTest("Not authorized to use experiment service.")
-
-    @classmethod
-    @requires_provider
-    def _setup_provider(cls, provider):
-        """Get the provider for the class."""
-        return provider
 
     def test_default_preferences(self):
         """Test getting default preferences."""

--- a/test/ibm/experiment/test_experiment_server_integration.py
+++ b/test/ibm/experiment/test_experiment_server_integration.py
@@ -35,22 +35,20 @@ class TestExperimentServerIntegration(IBMTestCase):
     """Test experiment modules."""
 
     @classmethod
-    def setUpClass(cls):
+    @requires_provider
+    def setUpClass(cls, provider, hub, group, project):
         """Initial class level setup."""
         # pylint: disable=arguments-differ
         super().setUpClass()
-        cls.provider = cls._setup_provider()  # pylint: disable=no-value-for-parameter
+        cls.provider = provider
+        cls.hub = hub
+        cls.group = group
+        cls.project = project
         cls.backend = cls._setup_backend()  # pylint: disable=no-value-for-parameter
         try:
             cls.device_components = cls.provider.experiment.device_components(cls.backend.name())
         except Exception:
             raise SkipTest("Not authorized to use experiment service.")
-
-    @classmethod
-    @requires_provider
-    def _setup_provider(cls, provider):
-        """Get the provider for the class."""
-        return provider
 
     @classmethod
     @requires_device
@@ -241,12 +239,10 @@ class TestExperimentServerIntegration(IBMTestCase):
     def test_experiments_with_hgp(self):
         """Test retrieving all experiments for a specific h/g/p."""
         exp_id = self._create_experiment()
-        credentials = self.provider.credentials
-        hgp = [credentials.hub, credentials.group, credentials.project]
         sub_tests = [
-            {'hub': hgp[0]},
-            {'hub': hgp[0], 'group': hgp[1]},
-            {'hub': hgp[0], 'group': hgp[1], 'project': hgp[2]}
+            {'hub': self.hub},
+            {'hub': self.hub, 'group': self.group},
+            {'hub': self.hub, 'group': self.group, 'project': self.project}
         ]
 
         for hgp_kwargs in sub_tests:
@@ -498,10 +494,9 @@ class TestExperimentServerIntegration(IBMTestCase):
         self.assertEqual(exp_id, new_exp_id)
         new_exp = self.provider.experiment.experiment(new_exp_id)
 
-        credentials = self.provider.credentials
-        self.assertEqual(credentials.hub, new_exp["hub"])  # pylint: disable=no-member
-        self.assertEqual(credentials.group, new_exp["group"])  # pylint: disable=no-member
-        self.assertEqual(credentials.project, new_exp["project"])  # pylint: disable=no-member
+        self.assertEqual(self.hub, new_exp["hub"])  # pylint: disable=no-member
+        self.assertEqual(self.group, new_exp["group"])  # pylint: disable=no-member
+        self.assertEqual(self.project, new_exp["project"])  # pylint: disable=no-member
         self.assertEqual("qiskit_test", new_exp["experiment_type"])
         self.assertEqual(self.backend.name(), new_exp["backend"].name())
         self.assertEqual({"foo": "bar"}, new_exp["metadata"])

--- a/test/ibm/runtime/test_runtime.py
+++ b/test/ibm/runtime/test_runtime.py
@@ -738,7 +738,7 @@ if __name__ == '__main__':
         job = self._run_program(program_id)
         cred = Credentials(token="", url="", hub="hub2", group="group2", project="project2",
                            services={"runtime": "https://quantum-computing.ibm.com"})
-        self.runtime._hgp.credentials = cred
+        self.runtime._default_hgp.credentials = cred
         rjob = self.runtime.job(job.job_id)
         self.assertIsNotNone(rjob.backend)
 

--- a/test/ibm/runtime/test_runtime.py
+++ b/test/ibm/runtime/test_runtime.py
@@ -52,6 +52,7 @@ from qiskit.providers.jobstatus import JobStatus
 from qiskit_ibm.exceptions import IBMInputValueError
 from qiskit_ibm.ibm_provider import IBMProvider
 from qiskit_ibm.credentials import Credentials
+from qiskit_ibm.hub_group_project import HubGroupProject
 from qiskit_ibm.runtime.utils import RuntimeEncoder, RuntimeDecoder
 from qiskit_ibm.runtime import IBMRuntimeService, RuntimeJob
 from qiskit_ibm.runtime.constants import API_TO_JOB_ERROR_MESSAGE
@@ -122,9 +123,10 @@ class TestRuntime(IBMTestCase):
         """Initial test setup."""
         super().setUp()
         provider = mock.MagicMock(spec=IBMProvider)
-        provider.credentials = Credentials(
+        hgp = mock.MagicMock(spec=HubGroupProject)
+        hgp.credentials = Credentials(
             token="", url="", services={"runtime": "https://quantum-computing.ibm.com"})
-        self.runtime = IBMRuntimeService(provider)
+        self.runtime = IBMRuntimeService(provider, hgp)
         self.runtime._api_client = BaseFakeRuntimeClient()
 
     def test_coder(self):
@@ -736,7 +738,7 @@ if __name__ == '__main__':
         job = self._run_program(program_id)
         cred = Credentials(token="", url="", hub="hub2", group="group2", project="project2",
                            services={"runtime": "https://quantum-computing.ibm.com"})
-        self.runtime._provider.credentials = cred
+        self.runtime._hgp.credentials = cred
         rjob = self.runtime.job(job.job_id)
         self.assertIsNotNone(rjob.backend)
 
@@ -766,9 +768,11 @@ if __name__ == '__main__':
             self.runtime._api_client.set_hgp(hub, group, project)
         if program_id is None:
             program_id = self._upload_program()
-        job = self.runtime.run(program_id=program_id, inputs=inputs,
-                               options=options, result_decoder=decoder,
-                               image=image)
+        with patch('qiskit_ibm.runtime.ibm_runtime_service.RuntimeClient',
+                   return_value=self.runtime._api_client):
+            job = self.runtime.run(program_id=program_id, options=options,
+                                   inputs=inputs, result_decoder=decoder,
+                                   image=image)
         return job
 
     def _populate_jobs_with_all_statuses(self, jobs, program_id):

--- a/test/ibm/runtime/test_runtime_integration.py
+++ b/test/ibm/runtime/test_runtime_integration.py
@@ -75,7 +75,7 @@ def main(backend, user_messenger, **kwargs):
         "max_execution_time": 600,
         "description": "Qiskit test program"
     }
-    PROGRAM_PREFIX = 'qiskit-test'
+    PROGRAM_PREFIX = 'qiskit-test-rathish'
 
     @classmethod
     @requires_runtime_device
@@ -652,7 +652,7 @@ def main(backend, user_messenger, **kwargs):
         MockProxyServer(self, self.log).start()
         callback_called = False
 
-        with use_proxies(self.provider, MockProxyServer.VALID_PROXIES):
+        with use_proxies(self.provider.runtime._hgp, MockProxyServer.VALID_PROXIES):
             job = self._run_program(iterations=1, callback=result_callback)
             job.wait_for_final_state()
 
@@ -667,7 +667,7 @@ def main(backend, user_messenger, **kwargs):
         callback_called = False
         invalid_proxy = {'https': 'http://{}:{}'.format(MockProxyServer.PROXY_IP_ADDRESS,
                                                         MockProxyServer.INVALID_PROXY_PORT)}
-        with use_proxies(self.provider, invalid_proxy):
+        with use_proxies(self.provider.runtime._hgp, invalid_proxy):
             with self.assertLogs('qiskit_ibm', 'WARNING') as log_cm:
                 job = self._run_program(iterations=1, callback=result_callback)
                 job.wait_for_final_state()

--- a/test/ibm/runtime/test_runtime_integration.py
+++ b/test/ibm/runtime/test_runtime_integration.py
@@ -75,7 +75,7 @@ def main(backend, user_messenger, **kwargs):
         "max_execution_time": 600,
         "description": "Qiskit test program"
     }
-    PROGRAM_PREFIX = 'qiskit-test-rathish'
+    PROGRAM_PREFIX = 'qiskit-test'
 
     @classmethod
     @requires_runtime_device
@@ -652,7 +652,7 @@ def main(backend, user_messenger, **kwargs):
         MockProxyServer(self, self.log).start()
         callback_called = False
 
-        with use_proxies(self.provider.runtime._hgp, MockProxyServer.VALID_PROXIES):
+        with use_proxies(self.provider.runtime._default_hgp, MockProxyServer.VALID_PROXIES):
             job = self._run_program(iterations=1, callback=result_callback)
             job.wait_for_final_state()
 
@@ -667,7 +667,7 @@ def main(backend, user_messenger, **kwargs):
         callback_called = False
         invalid_proxy = {'https': 'http://{}:{}'.format(MockProxyServer.PROXY_IP_ADDRESS,
                                                         MockProxyServer.INVALID_PROXY_PORT)}
-        with use_proxies(self.provider.runtime._hgp, invalid_proxy):
+        with use_proxies(self.provider.runtime._default_hgp, invalid_proxy):
             with self.assertLogs('qiskit_ibm', 'WARNING') as log_cm:
                 job = self._run_program(iterations=1, callback=result_callback)
                 job.wait_for_final_state()

--- a/test/ibm/test_account_client.py
+++ b/test/ibm/test_account_client.py
@@ -44,7 +44,8 @@ class TestAccountClient(IBMTestCase):
         cls.hub = hub
         cls.group = group
         cls.project = project
-        cls.access_token = cls.provider.backend._hgp._api_client.account_api.session._access_token
+        default_hgp = cls.provider.backend._default_hgp
+        cls.access_token = default_hgp._api_client.account_api.session._access_token
 
     def setUp(self):
         """Initial test setup."""
@@ -73,7 +74,7 @@ class TestAccountClient(IBMTestCase):
     def _get_client(self):
         """Helper for instantiating an AccountClient."""
         # pylint: disable=no-value-for-parameter
-        return AccountClient(self.provider.backend._hgp.credentials)
+        return AccountClient(self.provider.backend._default_hgp.credentials)
 
     def test_exception_message(self):
         """Check exception has proper message."""
@@ -181,7 +182,8 @@ class TestAccountClientJobs(IBMTestCase):
         cls.hub = hub
         cls.group = group
         cls.project = project
-        cls.access_token = cls.provider.backend._hgp._api_client.account_api.session._access_token
+        default_hgp = cls.provider.backend._default_hgp
+        cls.access_token = default_hgp._api_client.account_api.session._access_token
 
         backend_name = 'ibmq_qasm_simulator'
         backend = cls.provider.get_backend(backend_name, hub=cls.hub,

--- a/test/ibm/test_account_client.py
+++ b/test/ibm/test_account_client.py
@@ -36,12 +36,15 @@ class TestAccountClient(IBMTestCase):
 
     @classmethod
     @requires_provider
-    def setUpClass(cls, provider):
+    def setUpClass(cls, provider, hub, group, project):
         """Initial class level setup."""
         # pylint: disable=arguments-differ
         super().setUpClass()
         cls.provider = provider
-        cls.access_token = cls.provider._api_client.account_api.session._access_token
+        cls.hub = hub
+        cls.group = group
+        cls.project = project
+        cls.access_token = cls.provider.backend._hgp._api_client.account_api.session._access_token
 
     def setUp(self):
         """Initial test setup."""
@@ -69,7 +72,8 @@ class TestAccountClient(IBMTestCase):
 
     def _get_client(self):
         """Helper for instantiating an AccountClient."""
-        return AccountClient(self.provider.credentials)  # pylint: disable=no-value-for-parameter
+        # pylint: disable=no-value-for-parameter
+        return AccountClient(self.provider.backend._hgp.credentials)
 
     def test_exception_message(self):
         """Check exception has proper message."""
@@ -102,7 +106,8 @@ class TestAccountClient(IBMTestCase):
     def test_access_token_not_in_exception_traceback(self):
         """Check that access token is replaced within chained request exceptions."""
         backend_name = 'ibmq_qasm_simulator'
-        backend = self.provider.get_backend(backend_name)
+        backend = self.provider.get_backend(backend_name, hub=self.hub,
+                                            group=self.group, project=self.project)
         circuit = transpile(self.qc1, backend, seed_transpiler=self.seed)
         qobj = assemble(circuit, backend, shots=1)
         client = backend._api_client
@@ -169,14 +174,18 @@ class TestAccountClientJobs(IBMTestCase):
 
     @classmethod
     @requires_provider
-    def setUpClass(cls, provider):
+    def setUpClass(cls, provider, hub, group, project):
         # pylint: disable=arguments-differ
         super().setUpClass()
         cls.provider = provider
-        cls.access_token = cls.provider._api_client.account_api.session._access_token
+        cls.hub = hub
+        cls.group = group
+        cls.project = project
+        cls.access_token = cls.provider.backend._hgp._api_client.account_api.session._access_token
 
         backend_name = 'ibmq_qasm_simulator'
-        backend = cls.provider.get_backend(backend_name)
+        backend = cls.provider.get_backend(backend_name, hub=cls.hub,
+                                           group=cls.group, project=cls.project)
         cls.client = backend._api_client
         cls.job = cls.client.job_submit(
             backend_name, cls._get_qobj(backend).to_dict())

--- a/test/ibm/test_composite_job.py
+++ b/test/ibm/test_composite_job.py
@@ -45,12 +45,16 @@ class TestIBMCompositeJob(IBMTestCase):
 
     @classmethod
     @requires_provider
-    def setUpClass(cls, provider):
+    def setUpClass(cls, provider, hub, group, project):
         """Initial class level setup."""
         # pylint: disable=arguments-differ
         super().setUpClass()
         cls.provider = provider
-        cls.sim_backend = provider.get_backend('ibmq_qasm_simulator')
+        cls.hub = hub
+        cls.group = group
+        cls.project = project
+        cls.sim_backend = provider.get_backend('ibmq_qasm_simulator', hub=cls.hub,
+                                               group=cls.group, project=cls.project)
         cls.last_week = datetime.now() - timedelta(days=7)
 
     def setUp(self):
@@ -689,12 +693,16 @@ class TestIBMCompositeJobIntegration(IBMTestCase):
 
     @classmethod
     @requires_provider
-    def setUpClass(cls, provider):
+    def setUpClass(cls, provider, hub, group, project):
         """Initial class level setup."""
         # pylint: disable=arguments-differ
         super().setUpClass()
         cls.provider = provider
-        cls.sim_backend = provider.get_backend('ibmq_qasm_simulator')
+        cls.hub = hub
+        cls.group = group
+        cls.project = project
+        cls.sim_backend = provider.get_backend('ibmq_qasm_simulator', hub=cls.hub,
+                                               group=cls.group, project=cls.project)
         cls._qc = transpile(ReferenceCircuits.bell(), backend=cls.sim_backend)
         cls.last_week = datetime.now() - timedelta(days=7)
 

--- a/test/ibm/test_ibm_backend.py
+++ b/test/ibm/test_ibm_backend.py
@@ -65,7 +65,8 @@ class TestIBMBackend(IBMTestCase):
         """Test backend reservations."""
         provider = self.backend.provider()
         backend = reservations = None
-        for backend in provider.backends(simulator=False, operational=True):
+        for backend in provider.backends(simulator=False, operational=True, hub=self.backend.hub,
+                                         group=self.backend.group, project=self.backend.project):
             reservations = backend.reservations()
             if reservations:
                 break
@@ -109,7 +110,8 @@ class TestIBMBackend(IBMTestCase):
     def test_backend_options(self):
         """Test backend options."""
         provider = self.backend.provider()
-        backends = provider.backends(open_pulse=True, operational=True)
+        backends = provider.backends(open_pulse=True, operational=True, hub=self.backend.hub,
+                                     group=self.backend.group, project=self.backend.project)
         if not backends:
             raise SkipTest('Skipping pulse test since no pulse backend found.')
 
@@ -131,7 +133,8 @@ class TestIBMBackend(IBMTestCase):
     def test_sim_backend_options(self):
         """Test simulator backend options."""
         provider = self.backend.provider()
-        backend = provider.get_backend('ibmq_qasm_simulator')
+        backend = provider.get_backend('ibmq_qasm_simulator', hub=self.backend.hub,
+                                       group=self.backend.group, project=self.backend.project)
         backend.options.shots = 2048
         backend.set_options(memory=True)
         job = backend.run(ReferenceCircuits.bell(), shots=1024, foo='foo')
@@ -177,11 +180,14 @@ class TestIBMBackendService(IBMTestCase):
 
     @classmethod
     @requires_provider
-    def setUpClass(cls, provider):
+    def setUpClass(cls, provider, hub, group, project):
         """Initial class level setup."""
         # pylint: disable=arguments-differ
         super().setUpClass()
         cls.provider = provider
+        cls.hub = hub
+        cls.group = group
+        cls.project = project
         cls.last_week = datetime.now() - timedelta(days=7)
 
     def test_my_reservations(self):

--- a/test/ibm/test_ibm_integration.py
+++ b/test/ibm/test_ibm_integration.py
@@ -31,12 +31,16 @@ class TestIBMIntegration(IBMTestCase):
 
     @classmethod
     @requires_provider
-    def setUpClass(cls, provider):
+    def setUpClass(cls, provider, hub, group, project):
         """Initial class level setup."""
         # pylint: disable=arguments-differ
         super().setUpClass()
         cls.provider = provider
-        cls.sim_backend = provider.get_backend('ibmq_qasm_simulator')
+        cls.hub = hub
+        cls.group = group
+        cls.project = project
+        cls.sim_backend = provider.get_backend('ibmq_qasm_simulator', hub=cls.hub,
+                                               group=cls.group, project=cls.project)
 
     def setUp(self):
         super().setUp()
@@ -111,9 +115,9 @@ class TestIBMIntegration(IBMTestCase):
         self.assertIsInstance(results, Result)
 
     @requires_private_provider
-    def test_private_job(self, provider):
+    def test_private_job(self, provider, hub, group, project):
         """Test a private job."""
-        backend = provider.get_backend('ibmq_qasm_simulator')
+        backend = provider.get_backend('ibmq_qasm_simulator', hub, group, project)
         qc = ReferenceCircuits.bell()
         job = execute(qc, backend=backend)
         self.assertIsNotNone(job.circuits())

--- a/test/ibm/test_ibm_job_attributes.py
+++ b/test/ibm/test_ibm_job_attributes.py
@@ -41,12 +41,16 @@ class TestIBMJobAttributes(IBMTestCase):
 
     @classmethod
     @requires_provider
-    def setUpClass(cls, provider):
+    def setUpClass(cls, provider, hub, group, project):
         """Initial class level setup."""
         # pylint: disable=arguments-differ
         super().setUpClass()
         cls.provider = provider
-        cls.sim_backend = provider.get_backend('ibmq_qasm_simulator')
+        cls.hub = hub
+        cls.group = group
+        cls.project = project
+        cls.sim_backend = provider.get_backend('ibmq_qasm_simulator', hub=cls.hub,
+                                               group=cls.group, project=cls.project)
         cls.bell = transpile(ReferenceCircuits.bell(), cls.sim_backend)
         cls.sim_job = cls.sim_backend.run(cls.bell)
         cls.last_week = datetime.now() - timedelta(days=7)
@@ -253,7 +257,8 @@ class TestIBMJobAttributes(IBMTestCase):
     def test_queue_info(self):
         """Test retrieving queue information."""
         # Find the most busy backend.
-        backend = most_busy_backend(self.provider)
+        backend = most_busy_backend(self.provider, hub=self.hub,
+                                    group=self.group, project=self.project)
         leave_states = list(JOB_FINAL_STATES) + [JobStatus.RUNNING]
         job = backend.run(self.bell)
         queue_info = None

--- a/test/ibm/test_ibm_job_states.py
+++ b/test/ibm/test_ibm_job_states.py
@@ -400,8 +400,8 @@ class TestIBMJobStates(JobTestCase):
 
     def run_with_api(self, api):
         """Creates a new ``IBMJob`` running with the provided API object."""
-        backend = IBMBackend(FakeBogota().configuration(),
-                             mock.Mock(), mock.Mock(), api_client=api)
+        backend = IBMBackend(FakeBogota().configuration(), mock.Mock(),
+                             mock.Mock(), api_client=api)
         circuit = transpile(ReferenceCircuits.bell())
         self._current_api = api
         self._current_qjob = backend.run(circuit)

--- a/test/ibm/test_ibm_provider.py
+++ b/test/ibm/test_ibm_provider.py
@@ -58,7 +58,7 @@ class TestIBMProviderEnableAccount(IBMTestCase):
         # pylint: disable=unused-argument
         provider = IBMProvider(token=qe_token)
         self.assertIsInstance(provider, IBMProvider)
-        self.assertEqual(provider.backend._hgp.credentials.token, qe_token)
+        self.assertEqual(provider.backend._default_hgp.credentials.token, qe_token)
 
     @requires_qe_access
     def test_pass_unreachable_proxy(self, qe_token, qe_url):
@@ -143,8 +143,8 @@ class TestIBMProviderAccounts(IBMTestCase):
             provider = IBMProvider()
 
         self.assertIsInstance(provider, IBMProvider)
-        self.assertEqual(provider.backend._hgp.credentials.token, qe_token)
-        self.assertEqual(provider.backend._hgp.credentials.auth_url, qe_url)
+        self.assertEqual(provider.backend._default_hgp.credentials.token, qe_token)
+        self.assertEqual(provider.backend._default_hgp.credentials.auth_url, qe_url)
 
     def test_save_account_specified_provider(self):
         """Test saving an account with a specified hub/group/project."""
@@ -204,21 +204,21 @@ class TestIBMProviderAccounts(IBMTestCase):
                                      group=non_default_hgp.credentials.group,
                                      project=non_default_hgp.credentials.project)
             saved_provider = IBMProvider()
-            if saved_provider.backend._hgp != non_default_hgp:
+            if saved_provider.backend._default_hgp != non_default_hgp:
                 # Prevent tokens from being logged.
-                saved_provider.backend._hgp.credentials.token = None
+                saved_provider.backend._default_hgp.credentials.token = None
                 non_default_hgp.credentials.token = None
                 self.fail("loaded default hgp ({}) != expected ({})".format(
-                    saved_provider.backend._hgp.credentials.__dict__,
+                    saved_provider.backend._default_hgp.credentials.__dict__,
                     non_default_hgp.credentials.__dict__))
 
-        self.assertEqual(saved_provider.backend._hgp.credentials.token, qe_token)
-        self.assertEqual(saved_provider.backend._hgp.credentials.auth_url, qe_url)
-        self.assertEqual(saved_provider.backend._hgp.credentials.hub,
+        self.assertEqual(saved_provider.backend._default_hgp.credentials.token, qe_token)
+        self.assertEqual(saved_provider.backend._default_hgp.credentials.auth_url, qe_url)
+        self.assertEqual(saved_provider.backend._default_hgp.credentials.hub,
                          non_default_hgp.credentials.hub)
-        self.assertEqual(saved_provider.backend._hgp.credentials.group,
+        self.assertEqual(saved_provider.backend._default_hgp.credentials.group,
                          non_default_hgp.credentials.group)
-        self.assertEqual(saved_provider.backend._hgp.credentials.project,
+        self.assertEqual(saved_provider.backend._default_hgp.credentials.project,
                          non_default_hgp.credentials.project)
 
     @requires_qe_access
@@ -296,7 +296,7 @@ class TestIBMProviderHubGroupProject(IBMTestCase):
         super().setUp()
 
         self.provider = self._initialize_provider()
-        self.credentials = self.provider.backend._hgp.credentials
+        self.credentials = self.provider.backend._default_hgp.credentials
 
     def test_get_hgp(self):
         """Test get single hgp."""
@@ -304,7 +304,7 @@ class TestIBMProviderHubGroupProject(IBMTestCase):
             hub=self.credentials.hub,
             group=self.credentials.group,
             project=self.credentials.project)
-        self.assertEqual(self.provider.backend._hgp, hgp)
+        self.assertEqual(self.provider.backend._default_hgp, hgp)
 
     def test_get_hgps_with_filter(self):
         """Test get hgps with a filter."""
@@ -312,12 +312,12 @@ class TestIBMProviderHubGroupProject(IBMTestCase):
             hub=self.credentials.hub,
             group=self.credentials.group,
             project=self.credentials.project)[0]
-        self.assertEqual(self.provider.backend._hgp, hgp)
+        self.assertEqual(self.provider.backend._default_hgp, hgp)
 
     def test_get_hgps_no_filter(self):
         """Test get hgps without a filter."""
         hgps = self.provider._get_hgps()
-        self.assertIn(self.provider.backend._hgp, hgps)
+        self.assertIn(self.provider.backend._default_hgp, hgps)
 
 
 class TestIBMProviderServices(IBMTestCase, providers.ProviderTestCase):

--- a/test/ibm/test_ibm_provider.py
+++ b/test/ibm/test_ibm_provider.py
@@ -25,22 +25,23 @@ from qiskit.providers.models.backendproperties import BackendProperties
 from qiskit_ibm.ibm_backend import IBMSimulator, IBMBackend
 from qiskit_ibm.ibm_backend_service import IBMBackendService
 from qiskit_ibm.experiment import IBMExperimentService
-from qiskit_ibm.random.ibm_random_service import IBMRandomService
+from qiskit_ibm.random import IBMRandomService
+from qiskit_ibm.runtime import IBMRuntimeService
 from qiskit_ibm.ibm_provider import IBMProvider
-from qiskit_ibm import ibm_provider
+from qiskit_ibm import hub_group_project
 from qiskit_ibm.api.exceptions import RequestsApiError
 from qiskit_ibm.api.clients import AccountClient
 from qiskit_ibm.exceptions import (IBMProviderError, IBMProviderValueError,
                                    IBMProviderCredentialsInvalidUrl,
                                    IBMProviderCredentialsInvalidToken,
                                    IBMProviderCredentialsNotFound)
-from qiskit_ibm.credentials.hubgroupproject import HubGroupProject
+from qiskit_ibm.credentials.hub_group_project_id import HubGroupProjectID
 from qiskit_ibm.apiconstants import QISKIT_IBM_API_URL
 
 from ..ibm_test_case import IBMTestCase
-from ..decorators import requires_device, requires_provider, requires_qe_access
+from ..decorators import requires_device, requires_qe_access, requires_provider
 from ..contextmanagers import custom_qiskitrc, no_envs, CREDENTIAL_ENV_VARS
-from ..utils import get_provider
+from ..utils import get_hgp
 
 API_URL = 'https://api.quantum-computing.ibm.com/api'
 AUTH_URL = 'https://auth.quantum-computing.ibm.com/api'
@@ -57,51 +58,7 @@ class TestIBMProviderEnableAccount(IBMTestCase):
         # pylint: disable=unused-argument
         provider = IBMProvider(token=qe_token)
         self.assertIsInstance(provider, IBMProvider)
-        self.assertEqual(provider.credentials.token, qe_token)
-        self.assertEqual(provider.credentials.hub, 'ibm-q')
-        self.assertEqual(provider.credentials.group, 'open')
-        self.assertEqual(provider.credentials.project, 'main')
-
-    @requires_qe_access
-    def test_provider_init_token_url_hub(self, qe_token, qe_url):
-        """Test initializing IBMProvider with API token, URL and Hub."""
-        provider = IBMProvider(token=qe_token, url=qe_url, hub='ibm-q')
-        self.assertIsInstance(provider, IBMProvider)
-        self.assertEqual(provider.credentials.token, qe_token)
-        self.assertEqual(provider.credentials.hub, 'ibm-q')
-        self.assertEqual(provider.credentials.group, 'open')
-        self.assertEqual(provider.credentials.project, 'main')
-
-    @requires_qe_access
-    def test_provider_init_token_url_group(self, qe_token, qe_url):
-        """Test initializing IBMProvider with API token, URL and Group."""
-        provider = IBMProvider(token=qe_token, url=qe_url, group='open')
-        self.assertIsInstance(provider, IBMProvider)
-        self.assertEqual(provider.credentials.token, qe_token)
-        self.assertEqual(provider.credentials.hub, 'ibm-q')
-        self.assertEqual(provider.credentials.group, 'open')
-        self.assertEqual(provider.credentials.project, 'main')
-
-    @requires_qe_access
-    def test_provider_init_token_url_project(self, qe_token, qe_url):
-        """Test initializing IBMProvider with API token, URL and Project."""
-        provider = IBMProvider(token=qe_token, url=qe_url, project='main')
-        self.assertIsInstance(provider, IBMProvider)
-        self.assertEqual(provider.credentials.token, qe_token)
-        self.assertEqual(provider.credentials.hub, 'ibm-q')
-        self.assertEqual(provider.credentials.group, 'open')
-        self.assertEqual(provider.credentials.project, 'main')
-
-    @requires_qe_access
-    def test_provider_init_non_default_provider(self, qe_token, qe_url):
-        """Test initializing IBMProvider with a non default provider."""
-        non_default_provider = get_provider(qe_token, qe_url, default=False)
-        enabled_provider = IBMProvider(
-            token=qe_token, url=qe_url,
-            hub=non_default_provider.credentials.hub,
-            group=non_default_provider.credentials.group,
-            project=non_default_provider.credentials.project)
-        self.assertEqual(non_default_provider, enabled_provider)
+        self.assertEqual(provider.backend._hgp.credentials.token, qe_token)
 
     @requires_qe_access
     def test_pass_unreachable_proxy(self, qe_token, qe_url):
@@ -113,7 +70,6 @@ class TestIBMProviderEnableAccount(IBMTestCase):
             }
         }
         with self.assertRaises(RequestsApiError) as context_manager:
-            IBMProvider._disable_account()
             IBMProvider(qe_token, qe_url, proxies=proxies)
         self.assertIn('ProxyError', str(context_manager.exception))
 
@@ -151,8 +107,7 @@ class TestIBMProviderEnableAccount(IBMTestCase):
         """Test discovering backends failed."""
         with mock.patch.object(AccountClient, 'list_backends',
                                return_value=[{'backend_name': 'bad_backend'}]):
-            with self.assertLogs(ibm_provider.logger, level='WARNING') as context_manager:
-                IBMProvider._disable_account()
+            with self.assertLogs(hub_group_project.logger, level='WARNING') as context_manager:
                 IBMProvider(qe_token, qe_url)
         self.assertIn('bad_backend', str(context_manager.output))
 
@@ -188,20 +143,17 @@ class TestIBMProviderAccounts(IBMTestCase):
             provider = IBMProvider()
 
         self.assertIsInstance(provider, IBMProvider)
-        self.assertEqual(provider.credentials.token, qe_token)
-        self.assertEqual(provider.credentials.auth_url, qe_url)
-        self.assertEqual(provider.credentials.hub, 'ibm-q')
-        self.assertEqual(provider.credentials.group, 'open')
-        self.assertEqual(provider.credentials.project, 'main')
+        self.assertEqual(provider.backend._hgp.credentials.token, qe_token)
+        self.assertEqual(provider.backend._hgp.credentials.auth_url, qe_url)
 
     def test_save_account_specified_provider(self):
-        """Test saving an account with a specified provider."""
+        """Test saving an account with a specified hub/group/project."""
         default_hgp_to_save = 'ibm-q/open/main'
 
         with custom_qiskitrc() as custom_qiskitrc_cm:
-            hgp = HubGroupProject.from_stored_format(default_hgp_to_save)
+            hgp_id = HubGroupProjectID.from_stored_format(default_hgp_to_save)
             IBMProvider.save_account(token=self.token, url=QISKIT_IBM_API_URL,
-                                     hub=hgp.hub, group=hgp.group, project=hgp.project)
+                                     hub=hgp_id.hub, group=hgp_id.group, project=hgp_id.project)
 
             # Ensure the `default_provider` name was written to the config file.
             config_parser = ConfigParser()
@@ -214,16 +166,16 @@ class TestIBMProviderAccounts(IBMTestCase):
 
     def test_save_account_specified_provider_invalid(self):
         """Test saving an account without specifying all the hub/group/project fields."""
-        invalid_hgps_to_save = [HubGroupProject('', 'default_group', ''),
-                                HubGroupProject('default_hub', None, 'default_project')]
-        for invalid_hgp in invalid_hgps_to_save:
-            with self.subTest(invalid_hgp=invalid_hgp), custom_qiskitrc():
+        invalid_hgp_ids_to_save = [HubGroupProjectID('', 'default_group', ''),
+                                   HubGroupProjectID('default_hub', None, 'default_project')]
+        for invalid_hgp_id in invalid_hgp_ids_to_save:
+            with self.subTest(invalid_hgp_id=invalid_hgp_id), custom_qiskitrc():
                 with self.assertRaises(IBMProviderValueError) as context_manager:
                     IBMProvider.save_account(token=self.token,
                                              url=QISKIT_IBM_API_URL,
-                                             hub=invalid_hgp.hub,
-                                             group=invalid_hgp.group,
-                                             project=invalid_hgp.project)
+                                             hub=invalid_hgp_id.hub,
+                                             group=invalid_hgp_id.group,
+                                             project=invalid_hgp_id.project)
                 self.assertIn('The hub, group, and project parameters must all be specified',
                               str(context_manager.exception))
 
@@ -238,38 +190,40 @@ class TestIBMProviderAccounts(IBMTestCase):
 
     @requires_qe_access
     def test_load_account_saved_provider(self, qe_token, qe_url):
-        """Test loading an account that contains a saved provider."""
+        """Test loading an account that contains a saved hub/group/project."""
         if qe_url != QISKIT_IBM_API_URL:
             # .save_account() expects an auth production URL.
             self.skipTest('Test requires production auth URL')
 
-        # Get a non default provider.
-        non_default_provider = get_provider(qe_token, qe_url, default=False)
+        # Get a non default hub/group/project.
+        non_default_hgp = get_hgp(qe_token, qe_url, default=False)
 
         with custom_qiskitrc(), no_envs(CREDENTIAL_ENV_VARS):
             IBMProvider.save_account(token=qe_token, url=qe_url,
-                                     hub=non_default_provider.credentials.hub,
-                                     group=non_default_provider.credentials.group,
-                                     project=non_default_provider.credentials.project)
+                                     hub=non_default_hgp.credentials.hub,
+                                     group=non_default_hgp.credentials.group,
+                                     project=non_default_hgp.credentials.project)
             saved_provider = IBMProvider()
-            if saved_provider != non_default_provider:
+            if saved_provider.backend._hgp != non_default_hgp:
                 # Prevent tokens from being logged.
-                saved_provider.credentials.token = None
-                non_default_provider.credentials.token = None
-                self.fail("loaded default provider ({}) != expected ({})".format(
-                    saved_provider.credentials.__dict__,
-                    non_default_provider.credentials.__dict__))
+                saved_provider.backend._hgp.credentials.token = None
+                non_default_hgp.credentials.token = None
+                self.fail("loaded default hgp ({}) != expected ({})".format(
+                    saved_provider.backend._hgp.credentials.__dict__,
+                    non_default_hgp.credentials.__dict__))
 
-        self.assertEqual(saved_provider.credentials.token, qe_token)
-        self.assertEqual(saved_provider.credentials.auth_url, qe_url)
-        self.assertEqual(saved_provider.credentials.hub, non_default_provider.credentials.hub)
-        self.assertEqual(saved_provider.credentials.group, non_default_provider.credentials.group)
-        self.assertEqual(saved_provider.credentials.project,
-                         non_default_provider.credentials.project)
+        self.assertEqual(saved_provider.backend._hgp.credentials.token, qe_token)
+        self.assertEqual(saved_provider.backend._hgp.credentials.auth_url, qe_url)
+        self.assertEqual(saved_provider.backend._hgp.credentials.hub,
+                         non_default_hgp.credentials.hub)
+        self.assertEqual(saved_provider.backend._hgp.credentials.group,
+                         non_default_hgp.credentials.group)
+        self.assertEqual(saved_provider.backend._hgp.credentials.project,
+                         non_default_hgp.credentials.project)
 
     @requires_qe_access
-    def test_load_account_saved_provider_invalid_hgp(self, qe_token, qe_url):
-        """Test loading an account that contains a saved provider that does not exist."""
+    def test_load_saved_account_invalid_hgp(self, qe_token, qe_url):
+        """Test loading an account that contains a saved hub/group/project that does not exist."""
         if qe_url != QISKIT_IBM_API_URL:
             # .save_account() expects an auth production URL.
             self.skipTest('Test requires production auth URL')
@@ -277,16 +231,16 @@ class TestIBMProviderAccounts(IBMTestCase):
         # Hub, group, project in correct format but does not exists.
         invalid_hgp_to_store = 'invalid_hub/invalid_group/invalid_project'
         with custom_qiskitrc(), no_envs(CREDENTIAL_ENV_VARS):
-            hgp = HubGroupProject.from_stored_format(invalid_hgp_to_store)
+            hgp_id = HubGroupProjectID.from_stored_format(invalid_hgp_to_store)
             with self.assertRaises(IBMProviderError) as context_manager:
-                IBMProvider.save_account(token=qe_token, url=qe_url,
-                                         hub=hgp.hub, group=hgp.group, project=hgp.project)
+                IBMProvider.save_account(token=qe_token, url=qe_url, hub=hgp_id.hub,
+                                         group=hgp_id.group, project=hgp_id.project)
                 IBMProvider()
 
-            self.assertIn('No provider matches the specified criteria',
+            self.assertIn('No hub/group/project matches the specified criteria',
                           str(context_manager.exception))
 
-    def test_load_account_saved_provider_invalid_format(self):
+    def test_load_saved_account_invalid_hgp_format(self):
         """Test loading an account that contains a saved provider in an invalid format."""
         # Format {'test_case_input': 'error message from raised exception'}
         invalid_hgps = {
@@ -310,20 +264,10 @@ class TestIBMProviderAccounts(IBMTestCase):
                     self.assertIn(error_message, str(context_manager.exception))
 
     @requires_qe_access
-    def test_disable_account(self, qe_token, qe_url):
-        """Test disabling an account """
-        IBMProvider(qe_token, qe_url)
-        IBMProvider._disable_account()
-        self.assertFalse(IBMProvider._providers)
-
-    @requires_qe_access
     def test_active_account(self, qe_token, qe_url):
         """Test get active account """
-        IBMProvider._disable_account()
-        self.assertIsNone(IBMProvider.active_account())
-
-        IBMProvider(qe_token, qe_url)
-        active_account = IBMProvider.active_account()
+        provider = IBMProvider(qe_token, qe_url)
+        active_account = provider.active_account()
         self.assertIsNotNone(active_account)
         self.assertEqual(active_account['token'], qe_token)
         self.assertEqual(active_account['url'], qe_url)
@@ -339,41 +283,41 @@ class TestIBMProviderAccounts(IBMTestCase):
                               str(context_manager.exception))
 
 
-class TestIBMProviderProvider(IBMTestCase):
-    """Tests for IBMProvider provider related methods."""
+class TestIBMProviderHubGroupProject(IBMTestCase):
+    """Tests for IBMProvider HubGroupProject related methods."""
 
     @requires_qe_access
-    def _get_provider(self, qe_token=None, qe_url=None):
-        """Return default provider."""
+    def _initialize_provider(self, qe_token=None, qe_url=None):
+        """Initialize and return provider."""
         return IBMProvider(qe_token, qe_url)
 
     def setUp(self):
         """Initial test setup."""
         super().setUp()
 
-        self.provider = self._get_provider()
-        self.credentials = self.provider.credentials
+        self.provider = self._initialize_provider()
+        self.credentials = self.provider.backend._hgp.credentials
 
-    def test_get_provider(self):
-        """Test get single provider."""
-        provider = IBMProvider._get_provider(
+    def test_get_hgp(self):
+        """Test get single hgp."""
+        hgp = self.provider._get_hgp(
             hub=self.credentials.hub,
             group=self.credentials.group,
             project=self.credentials.project)
-        self.assertEqual(self.provider, provider)
+        self.assertEqual(self.provider.backend._hgp, hgp)
 
-    def test_providers_with_filter(self):
-        """Test providers() with a filter."""
-        provider = IBMProvider.providers(
+    def test_get_hgps_with_filter(self):
+        """Test get hgps with a filter."""
+        hgp = self.provider._get_hgps(
             hub=self.credentials.hub,
             group=self.credentials.group,
             project=self.credentials.project)[0]
-        self.assertEqual(self.provider, provider)
+        self.assertEqual(self.provider.backend._hgp, hgp)
 
-    def test_providers_no_filter(self):
-        """Test providers() without a filter."""
-        providers_list = IBMProvider.providers()
-        self.assertIn(self.provider, providers_list)
+    def test_get_hgps_no_filter(self):
+        """Test get hgps without a filter."""
+        hgps = self.provider._get_hgps()
+        self.assertIn(self.provider.backend._hgp, hgps)
 
 
 class TestIBMProviderServices(IBMTestCase, providers.ProviderTestCase):
@@ -392,43 +336,50 @@ class TestIBMProviderServices(IBMTestCase, providers.ProviderTestCase):
         self.qc1.measure(qr, cr)
 
     @requires_provider
-    def _get_provider(self, provider):
+    def _get_provider(self, provider, hub, group, project):
         """Return an instance of a provider."""
         # pylint: disable=arguments-differ
+        self.hub = hub
+        self.group = group
+        self.project = project
         return provider
 
     def test_remote_backends_exist_real_device(self):
         """Test if there are remote backends that are devices."""
-        remotes = self.provider.backends(simulator=False)
+        remotes = self.provider.backends(simulator=False, hub=self.hub,
+                                         group=self.group, project=self.project)
         self.assertTrue(remotes)
 
     def test_remote_backends_exist_simulator(self):
         """Test if there are remote backends that are simulators."""
-        remotes = self.provider.backends(simulator=True)
+        remotes = self.provider.backends(simulator=True, hub=self.hub,
+                                         group=self.group, project=self.project)
         self.assertTrue(remotes)
 
     def test_remote_backends_instantiate_simulators(self):
         """Test if remote backends that are simulators are an ``IBMSimulator`` instance."""
-        remotes = self.provider.backends(simulator=True)
+        remotes = self.provider.backends(simulator=True, hub=self.hub,
+                                         group=self.group, project=self.project)
         for backend in remotes:
             with self.subTest(backend=backend):
                 self.assertIsInstance(backend, IBMSimulator)
 
     def test_remote_backend_status(self):
         """Test backend_status."""
-        remotes = self.provider.backends()
+        remotes = self.provider.backends(hub=self.hub, group=self.group, project=self.project)
         for backend in remotes:
             _ = backend.status()
 
     def test_remote_backend_configuration(self):
         """Test backend configuration."""
-        remotes = self.provider.backends()
+        remotes = self.provider.backends(hub=self.hub, group=self.group, project=self.project)
         for backend in remotes:
             _ = backend.configuration()
 
     def test_remote_backend_properties(self):
         """Test backend properties."""
-        remotes = self.provider.backends(simulator=False)
+        remotes = self.provider.backends(simulator=False, hub=self.hub,
+                                         group=self.group, project=self.project)
         for backend in remotes:
             properties = backend.properties()
             if backend.configuration().simulator:
@@ -436,7 +387,8 @@ class TestIBMProviderServices(IBMTestCase, providers.ProviderTestCase):
 
     def test_headers_in_result_sims(self):
         """Test that the qobj headers are passed onto the results for sims."""
-        backend = self.provider.get_backend('ibmq_qasm_simulator')
+        backend = self.provider.get_backend('ibmq_qasm_simulator', hub=self.hub, group=self.group,
+                                            project=self.project)
 
         custom_header = {'x': 1, 'y': [1, 2, 3], 'z': {'a': 4}}
         circuits = transpile(self.qc1, backend=backend)
@@ -474,7 +426,9 @@ class TestIBMProviderServices(IBMTestCase, providers.ProviderTestCase):
             with self.subTest(display_name=display_name,
                               backend_name=backend_name):
                 try:
-                    backend_by_name = self.provider.get_backend(backend_name)
+                    backend_by_name = self.provider.get_backend(backend_name, hub=self.hub,
+                                                                group=self.group,
+                                                                project=self.project)
                 except QiskitBackendNotFoundError:
                     # The real name of the backend might not exist
                     pass
@@ -487,7 +441,8 @@ class TestIBMProviderServices(IBMTestCase, providers.ProviderTestCase):
 
     def test_remote_backend_properties_filter_date(self):
         """Test backend properties filtered by date."""
-        backends = self.provider.backends(simulator=False)
+        backends = self.provider.backends(simulator=False, hub=self.hub,
+                                          group=self.group, project=self.project)
 
         datetime_filter = datetime(2019, 2, 1).replace(tzinfo=None)
         for backend in backends:
@@ -503,7 +458,7 @@ class TestIBMProviderServices(IBMTestCase, providers.ProviderTestCase):
         """Test provider_backends have correct attributes."""
         provider_backends = {back for back in dir(self.provider.backend)
                              if isinstance(getattr(self.provider.backend, back), IBMBackend)}
-        backends = {back.name().lower() for back in self.provider._backends.values()}
+        backends = {back.name().lower() for back in self.provider.backend._backends.values()}
         self.assertEqual(provider_backends, backends)
 
     def test_provider_services(self):
@@ -520,3 +475,6 @@ class TestIBMProviderServices(IBMTestCase, providers.ProviderTestCase):
         if 'random' in services:
             self.assertIsInstance(self.provider.service('random'), IBMRandomService)
             self.assertIsInstance(self.provider.random, IBMRandomService)
+        if 'runtime' in services:
+            self.assertIsInstance(self.provider.service('runtime'), IBMRuntimeService)
+            self.assertIsInstance(self.provider.runtime, IBMRuntimeService)

--- a/test/ibm/test_ibm_qasm_simulator.py
+++ b/test/ibm/test_ibm_qasm_simulator.py
@@ -27,12 +27,16 @@ class TestIBMQasmSimulator(IBMTestCase):
     """Test IBM Quantum QASM Simulator."""
 
     @requires_provider
-    def setUp(self, provider):
+    def setUp(self, provider, hub, group, project):
         """Initial test setup."""
         # pylint: disable=arguments-differ
         super().setUp()
         self.provider = provider
-        self.sim_backend = self.provider.get_backend('ibmq_qasm_simulator')
+        self.hub = hub
+        self.group = group
+        self.project = project
+        self.sim_backend = self.provider.get_backend('ibmq_qasm_simulator', hub=self.hub,
+                                                     group=self.group, project=self.project)
 
     def test_execute_one_circuit_simulator_online(self):
         """Test execute_one_circuit_simulator_online."""

--- a/test/ibm/test_jupyter.py
+++ b/test/ibm/test_jupyter.py
@@ -36,9 +36,12 @@ class TestBackendInfo(IBMTestCase):
 
     @classmethod
     @requires_provider
-    def setUpClass(cls, provider):
+    def setUpClass(cls, provider, hub, group, project):
         # pylint: disable=arguments-differ
         super().setUpClass()
+        cls.hub = hub
+        cls.group = group
+        cls.project = project
         cls.backends = _get_backends(provider)
 
     def test_config_tab(self):
@@ -88,18 +91,20 @@ class TestIBMDashboard(IBMTestCase):
 
     @classmethod
     @requires_provider
-    def setUpClass(cls, provider):
+    def setUpClass(cls, provider, hub, group, project):
         # pylint: disable=arguments-differ
         super().setUpClass()
         cls.provider = provider
+        cls.hub = hub
+        cls.group = group
+        cls.project = project
         cls.backends = _get_backends(provider)
 
     def test_backend_widget(self):
         """Test devices tab."""
         for backend in self.backends:
             with self.subTest(backend=backend):
-                cred = backend.provider().credentials
-                provider_str = "{}/{}/{}".format(cred.hub, cred.group, cred.project)
+                provider_str = "{}/{}/{}".format(backend.hub, backend.group, backend.project)
                 b_w_p = BackendWithProviders(backend=backend, providers=[provider_str])
                 make_backend_widget(b_w_p)
 

--- a/test/ibm/test_proxies.py
+++ b/test/ibm/test_proxies.py
@@ -63,7 +63,7 @@ class TestProxies(IBMTestCase):
         self.proxy_process.terminate()  # kill to be able of reading the output
 
         auth_line = pproxy_desired_access_log_line(qe_url)
-        api_line = pproxy_desired_access_log_line(provider.backend._hgp.credentials.url)
+        api_line = pproxy_desired_access_log_line(provider.backend._default_hgp.credentials.url)
         proxy_output = self.proxy_process.stdout.read().decode('utf-8')
 
         # Check if the authentication call went through proxy.

--- a/test/ibm/test_proxies.py
+++ b/test/ibm/test_proxies.py
@@ -57,21 +57,19 @@ class TestProxies(IBMTestCase):
     @requires_qe_access
     def test_proxies_ibm_account(self, qe_token, qe_url):
         """Should reach the proxy using account.enable."""
-        IBMProvider._disable_account()
         provider = IBMProvider(qe_token, qe_url,
                                proxies={'urls': VALID_PROXIES})
 
         self.proxy_process.terminate()  # kill to be able of reading the output
 
         auth_line = pproxy_desired_access_log_line(qe_url)
-        api_line = pproxy_desired_access_log_line(provider.credentials.url)
+        api_line = pproxy_desired_access_log_line(provider.backend._hgp.credentials.url)
         proxy_output = self.proxy_process.stdout.read().decode('utf-8')
 
         # Check if the authentication call went through proxy.
         self.assertIn(auth_line, proxy_output)
         # Check if the API call (querying providers list) went through proxy.
         self.assertIn(api_line, proxy_output)
-        IBMProvider._disable_account()
 
     @requires_qe_access
     def test_proxies_authclient(self, qe_token, qe_url):

--- a/test/ibm/test_registration.py
+++ b/test/ibm/test_registration.py
@@ -26,7 +26,7 @@ from qiskit_ibm.apiconstants import QISKIT_IBM_API_URL
 from qiskit_ibm.credentials import (
     Credentials, discover_credentials,
     read_credentials_from_qiskitrc, store_credentials,
-    store_preferences, HubGroupProject)
+    store_preferences, HubGroupProjectID)
 from qiskit_ibm.credentials import configrc
 from qiskit_ibm.exceptions import IBMProviderError
 
@@ -90,8 +90,8 @@ class TestCredentials(IBMTestCase):
                 provider = IBMProvider()
 
         # Ensure that the credentials are the overwritten ones.
-        # pylint: disable=unsubscriptable-object
-        self.assertEqual(provider['credentials'].token, credentials2.token)
+        # pylint: disable=no-member
+        self.assertEqual(provider._hgp['credentials'].token, credentials2.token)
 
     def test_environ_over_qiskitrc(self) -> None:
         """Test credential discovery order."""
@@ -330,11 +330,11 @@ class TestPreferences(IBMTestCase):
 
     def _get_pref_dict(
             self,
-            hgp: str = 'my-hub/my-group/my-project',
+            hgp_id: str = 'my-hub/my-group/my-project',
             cat: str = 'experiment',
             pref_key: str = 'auto_save',
             pref_val: Any = True
     ) -> Dict:
         """Generate a new preference dictionary."""
-        hub, group, project = hgp.split('/')
-        return {HubGroupProject(hub, group, project): {cat: {pref_key: pref_val}}}
+        hub, group, project = hgp_id.split('/')
+        return {HubGroupProjectID(hub, group, project): {cat: {pref_key: pref_val}}}

--- a/test/ibm/test_serialization.py
+++ b/test/ibm/test_serialization.py
@@ -35,12 +35,16 @@ class TestSerialization(IBMTestCase):
 
     @classmethod
     @requires_provider
-    def setUpClass(cls, provider):
+    def setUpClass(cls, provider, hub, group, project):
         """Initial class level setup."""
         # pylint: disable=arguments-differ
         super().setUpClass()
         cls.provider = provider
-        cls.sim_backend = provider.get_backend('ibmq_qasm_simulator')
+        cls.hub = hub
+        cls.group = group
+        cls.project = project
+        cls.sim_backend = provider.get_backend('ibmq_qasm_simulator', hub=cls.hub,
+                                               group=cls.group, project=cls.project)
         cls.bell = transpile(ReferenceCircuits.bell(), backend=cls.sim_backend)
 
     def test_qasm_qobj(self):
@@ -52,7 +56,8 @@ class TestSerialization(IBMTestCase):
 
     def test_pulse_qobj(self):
         """Test serializing pulse qobj data."""
-        backends = self.provider.backends(operational=True, open_pulse=True)
+        backends = self.provider.backends(operational=True, open_pulse=True, hub=self.hub,
+                                          group=self.group, project=self.project)
         if not backends:
             self.skipTest('Need pulse backends.')
 
@@ -75,7 +80,8 @@ class TestSerialization(IBMTestCase):
 
     def test_backend_configuration(self):
         """Test deserializing backend configuration."""
-        backends = self.provider.backends(operational=True, simulator=False)
+        backends = self.provider.backends(operational=True, simulator=False, hub=self.hub,
+                                          group=self.group, project=self.project)
 
         # Known keys that look like a serialized complex number.
         good_keys = ('coupling_map', 'qubit_lo_range', 'meas_lo_range', 'gates.coupling_map',
@@ -90,7 +96,8 @@ class TestSerialization(IBMTestCase):
 
     def test_pulse_defaults(self):
         """Test deserializing backend configuration."""
-        backends = self.provider.backends(operational=True, open_pulse=True)
+        backends = self.provider.backends(operational=True, open_pulse=True, hub=self.hub,
+                                          group=self.group, project=self.project)
         if not backends:
             self.skipTest('Need pulse backends.')
 
@@ -103,7 +110,8 @@ class TestSerialization(IBMTestCase):
 
     def test_backend_properties(self):
         """Test deserializing backend properties."""
-        backends = self.provider.backends(operational=True, simulator=False)
+        backends = self.provider.backends(operational=True, simulator=False, hub=self.hub,
+                                          group=self.group, project=self.project)
 
         # Known keys that look like a serialized object.
         good_keys = ('gates.qubits', 'qubits.name', 'backend_version')
@@ -125,7 +133,8 @@ class TestSerialization(IBMTestCase):
     @slow_test
     def test_pulse_job_result(self):
         """Test deserializing a pulse job result."""
-        backends = self.provider.backends(open_pulse=True, operational=True)
+        backends = self.provider.backends(open_pulse=True, operational=True, hub=self.hub,
+                                          group=self.group, project=self.project)
         if not backends:
             raise SkipTest('Skipping pulse test since no pulse backend found.')
 

--- a/test/ibm/websocket/test_websocket_integration.py
+++ b/test/ibm/websocket/test_websocket_integration.py
@@ -205,7 +205,7 @@ class TestWebsocketIntegration(IBMTestCase):
 
         # Manually disable the non-websocket polling.
         job._api_client._job_final_status_polling = self._job_final_status_polling
-        with use_proxies(self.provider.backend._hgp, MockProxyServer.VALID_PROXIES):
+        with use_proxies(self.provider.backend._default_hgp, MockProxyServer.VALID_PROXIES):
             result = job.result()
 
         self.assertEqual(result.status, 'COMPLETED')
@@ -217,7 +217,7 @@ class TestWebsocketIntegration(IBMTestCase):
 
         invalid_proxy = {'https': 'http://{}:{}'.format(MockProxyServer.PROXY_IP_ADDRESS,
                                                         MockProxyServer.INVALID_PROXY_PORT)}
-        with use_proxies(self.provider.backend._hgp, invalid_proxy):
+        with use_proxies(self.provider.backend._default_hgp, invalid_proxy):
             with self.assertLogs('qiskit_ibm', 'INFO') as log_cm:
                 job.wait_for_final_state()
 

--- a/test/proxy_server.py
+++ b/test/proxy_server.py
@@ -48,10 +48,10 @@ class MockProxyServer:
 
 
 @contextmanager
-def use_proxies(provider, proxies):
+def use_proxies(hgp, proxies):
     """Context manager to set and restore proxies setting."""
     try:
-        provider.credentials.proxies = {'urls': proxies}
+        hgp.credentials.proxies = {'urls': proxies}
         yield
     finally:
-        provider.credentials.proxies = None
+        hgp.credentials.proxies = None

--- a/test/utils.py
+++ b/test/utils.py
@@ -14,6 +14,7 @@
 
 import os
 import logging
+from typing import Optional
 
 from qiskit import QuantumCircuit
 from qiskit.qobj import QasmQobj
@@ -22,6 +23,7 @@ from qiskit.test.reference_circuits import ReferenceCircuits
 from qiskit.pulse import Schedule
 from qiskit.providers.exceptions import JobError
 from qiskit.providers.jobstatus import JobStatus
+from qiskit_ibm.hub_group_project import HubGroupProject
 from qiskit_ibm.ibm_provider import IBMProvider
 from qiskit_ibm.ibm_backend import IBMBackend
 from qiskit_ibm.job import IBMJob
@@ -53,7 +55,12 @@ def setup_test_logging(logger: logging.Logger, filename: str):
     logger.setLevel(os.getenv('LOG_LEVEL', 'DEBUG'))
 
 
-def most_busy_backend(provider: IBMProvider) -> IBMBackend:
+def most_busy_backend(
+        provider: IBMProvider,
+        hub: Optional[str] = None,
+        group: Optional[str] = None,
+        project: Optional[str] = None
+) -> IBMBackend:
     """Return the most busy backend for the provider given.
 
     Return the most busy available backend for those that
@@ -62,11 +69,15 @@ def most_busy_backend(provider: IBMProvider) -> IBMBackend:
 
     Args:
         provider: IBM Quantum account provider.
+        hub: Name of the hub.
+        group: Name of the group.
+        project: Name of the project.
 
     Returns:
         The most busy backend.
     """
-    backends = provider.backends(simulator=False, operational=True)
+    backends = provider.backends(simulator=False, operational=True,
+                                 hub=hub, group=group, project=project)
     return max([b for b in backends if b.configuration().n_qubits >= 5],
                key=lambda b: b.status().pending_jobs)
 
@@ -198,30 +209,30 @@ def get_pulse_schedule(backend: IBMBackend) -> Schedule:
     return schedules
 
 
-def get_provider(
+def get_hgp(
         qe_token: str,
         qe_url: str,
         default: bool = True
-) -> IBMProvider:
-    """Return a provider for the account.
+) -> HubGroupProject:
+    """Return a HubGroupProject for the account.
 
     Args:
         qe_token: IBM Quantum token.
         qe_url: IBM Quantum auth URL.
-        default: If `True`, the default open access project provider is returned.
-            Otherwise, a non open access project provider is returned.
+        default: If `True`, the default open access hgp is returned.
+            Otherwise, a non open access hgp is returned.
 
     Returns:
-        A provider, as specified by `default`.
+        A HubGroupProject, as specified by `default`.
     """
-    provider_to_return = IBMProvider(qe_token, url=qe_url)  # Default provider.
+    provider = IBMProvider(qe_token, url=qe_url)  # Default hub/group/project.
+    open_hgp = provider._get_hgp()  # Open access hgp
+    hgp_to_return = open_hgp
     if not default:
-        # Get a non default provider (i.e.not the default open access project).
-        providers = IBMProvider.providers()
-        for provider in providers:
-            if provider != provider_to_return:
-                provider_to_return = provider
+        # Get a non default hgp (i.e. not the default open access hgp).
+        hgps = provider._get_hgps()
+        for hgp in hgps:
+            if hgp != open_hgp:
+                hgp_to_return = hgp
                 break
-    IBMProvider._disable_account()
-
-    return provider_to_return
+    return hgp_to_return


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR primarily contains most of the changes for `IBMProvider`, `IBMBackendService` and `IBMRuntimeService`.
This PR ensures the happy path of initializing a provider, getting a backend and running a circuit continues to work fine. It also ensures that a backend is selected from appropriate hgp when backend name is passed to `runtime.run`.
The other file changes are merely the side effect of touching the above two files.

### Details and comments
Some of the changes INCLUDED in this PR are:
- Remove `providers()` method (Fixes #107)
- Remove ability to initialize provider with hub, group and project and implement hgp selection order (Fixes #108). As part of this PR hub, group and project can now be passed to the following methods.
  - `provider.get_backend()`
  - `provider.backends()`
  - `provider.run_circuits()`
  - `provider.runtime.run()`
  - `provider.experiment.create_experiment()`

### Changes NOT included in this PR (will be done as separate PRs)
- Make following IBMProvider methods work account level:
  - `has_service()`
  - `service()`
  - `services()`
  - `provider.backend.job()`
- Pass hub, group and project parameters to:
  - `provider.backend.jobs()`
- README update (#133)
- MIGRATING update (#134)
- Tutorials update (#135)