### PR TITLE
Fix failing integration tests

### DIFF
--- a/test/decorators.py
+++ b/test/decorators.py
@@ -112,13 +112,19 @@ def integration_test_setup(
 
             provider = None
             if init_provider:
-                provider = IBMProvider(token=token, url=url, instance=instance)
+                if instance:
+                    provider = IBMProvider(token=token, url=url, instance=instance)
+                if instance_private:
+                    private_provider = IBMProvider(
+                        token=token, url=url, instance=instance_private
+                    )
             dependencies = IntegrationTestDependencies(
                 token=token,
                 url=url,
                 instance=instance,
                 instance_private=instance_private,
                 provider=provider,
+                private_provider=private_provider,
             )
             kwargs["dependencies"] = dependencies
             func(self, *args, **kwargs)
@@ -133,7 +139,11 @@ class IntegrationTestDependencies:
     """Integration test dependencies."""
 
     provider: IBMProvider
+    private_provider: IBMProvider
     instance: Optional[str]
     instance_private: Optional[str]
     token: str
     url: str
+
+    def __getitem__(self, item):
+        return getattr(self, item)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Some tests were run using 1 public and 1 private provider in qiskit-ibmq-provider. Replicating that behavior here using QISKIT_IBM_INSTANCE_PRIVATE env variable, instead of running tests against all 6 or 7 providers attached to the test account, which was causing integration tests forever to complete and timeout eventually after 6 hours (https://github.com/Qiskit/qiskit-ibm-provider/actions/runs/2106829307).


### Details and comments


