### PR TITLE
Fix delay instruction error

### DIFF
--- a/qiskit_ibm_provider/utils/backend_converter.py
+++ b/qiskit_ibm_provider/utils/backend_converter.py
@@ -132,9 +132,10 @@ def convert_to_target(
                             target[inst][(qubit,)].calibration = sched
                     else:
                         target[inst][qarg].calibration = sched
-    target.add_instruction(
-        Delay(Parameter("t")), {(bit,): None for bit in range(target.num_qubits)}
-    )
+    if "delay" not in target.operation_names:
+        target.add_instruction(
+            Delay(Parameter("t")), {(bit,): None for bit in range(target.num_qubits)}
+        )
     return target
 
 

--- a/qiskit_ibm_provider/utils/backend_converter.py
+++ b/qiskit_ibm_provider/utils/backend_converter.py
@@ -132,7 +132,7 @@ def convert_to_target(
                             target[inst][(qubit,)].calibration = sched
                     else:
                         target[inst][qarg].calibration = sched
-    if "delay" not in target.operation_names:
+    if "delay" not in target:
         target.add_instruction(
             Delay(Parameter("t")), {(bit,): None for bit in range(target.num_qubits)}
         )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Recent PR https://github.com/Qiskit/qiskit-ibm-provider/pull/346 causing integration tests to fail with 
```AttributeError: Instruction delay is already in the target```

https://github.com/Qiskit/qiskit-ibm-provider/runs/6336245239?check_suite_focus=true#step:5:662

Do we need to add a check to see if the `delay` instruction is already present? 

### Details and comments


