### PR TITLE
Fix issue with retrieving composite job results 

### DIFF
--- a/qiskit_ibm_provider/job/ibm_composite_job.py
+++ b/qiskit_ibm_provider/job/ibm_composite_job.py
@@ -1227,10 +1227,10 @@ class IBMCompositeJob(IBMJob):
         if self._result and not refresh:
             return self._result
 
-        job_results = [
-            sub_job.result(refresh=refresh, partial=partial)
-            for sub_job in self._sub_jobs
-        ]
+        for sub_job in self._sub_jobs:
+            if not sub_job.job._use_object_storage:
+                sub_job.job.refresh()
+            job_results = [sub_job.result(refresh=refresh, partial=partial)]
 
         if not partial and any(result is None for result in job_results):
             return None

--- a/qiskit_ibm_provider/job/ibm_composite_job.py
+++ b/qiskit_ibm_provider/job/ibm_composite_job.py
@@ -1227,10 +1227,11 @@ class IBMCompositeJob(IBMJob):
         if self._result and not refresh:
             return self._result
 
+        job_results = []
         for sub_job in self._sub_jobs:
-            if not sub_job.job._use_object_storage:
+            if sub_job.job and not sub_job.job._use_object_storage:
                 sub_job.job.refresh()
-            job_results = [sub_job.result(refresh=refresh, partial=partial)]
+            job_results.append(sub_job.result(refresh=refresh, partial=partial))
 
         if not partial and any(result is None for result in job_results):
             return None

--- a/releasenotes/notes/composite-job-result-bug-16af9d32c7ca8099.yaml
+++ b/releasenotes/notes/composite-job-result-bug-16af9d32c7ca8099.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed a bug where :meth:`~qiskit_ibm_provider.job.IBMCompositeJob.result` would
+    error out because the results of sub jobs could not be retrieved. 

--- a/test/integration/test_composite_job.py
+++ b/test/integration/test_composite_job.py
@@ -853,6 +853,19 @@ class TestIBMCompositeJobIntegration(IBMTestCase):
                 for job_circ, rjob_circ in zip(job_circuits, rjob_circuits):
                     self.assertEqual(job_circ.data, rjob_circ.data)
 
+    def test_retrieve_result(self):
+        """Test retrieving the results of a composite job multiple times."""
+        job_tags = [uuid.uuid4().hex]
+        job_set = self.sim_backend.run(
+            [self._qc] * 2, max_circuits_per_job=1, job_tags=job_tags
+        )
+        job_set.block_for_submit()
+        # first time retrieving results
+        self.assertTrue(job_set.result())
+        rjob = self.dependencies.provider.job(job_set.job_id())
+        # second time retrieving results
+        self.assertTrue(rjob.result())
+
     def test_jobs(self):
         """Test retrieving a composite job using jobs."""
         job_tags = [uuid.uuid4().hex]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

There is a bug with retrieving the results of composite jobs multiple times - the sub job results are not being retrieved from object storage where they already exist.

```
composite_job = provider.job('ibm_composite_job_id_09aecdd52d3b45989fd2ef534528389d_')
composite_job.result()
```

Retrieving the results of a composite job errors with:

```
# IBMJobApiError: 'Unable to retrieve result for job 62def9ff556c2084afb59e6a: "Unexpected return value received from the server: \'qObjectResult\'"'
```

But retrieving the job results directly from the specified sub job works fine: 

```
sub_job = provider.job('62def9ff556c2084afb59e6a')
sub_job.result()
```

### Details and comments


