### PR TITLE
Handle missing qubit properties in Target generation

### DIFF
--- a/qiskit_ibm_provider/utils/backend_converter.py
+++ b/qiskit_ibm_provider/utils/backend_converter.py
@@ -149,15 +149,15 @@ def qubit_props_list_from_props(
     for qubit, _ in enumerate(properties.qubits):
         try:
             t_1 = properties.t1(qubit)
-        except Exception: # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             t_1 = None
         try:
             t_2 = properties.t2(qubit)
-        except Exception: # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             t_2 = None
         try:
             frequency = properties.frequency(qubit)
-        except Exception: # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             t_2 = None
         try:
             anharmonicity = properties.qubit_property(qubit, "anharmonicity")[0]

--- a/qiskit_ibm_provider/utils/backend_converter.py
+++ b/qiskit_ibm_provider/utils/backend_converter.py
@@ -153,7 +153,7 @@ def qubit_props_list_from_props(
             t_1 = None
         try:
             t_2 = properties.t2(qubit)
-        except Exception:
+        except Exception: # pylint: disable=broad-except
             t_2 = None
         try:
             frequency = properties.frequency(qubit)

--- a/qiskit_ibm_provider/utils/backend_converter.py
+++ b/qiskit_ibm_provider/utils/backend_converter.py
@@ -157,7 +157,7 @@ def qubit_props_list_from_props(
             t_2 = None
         try:
             frequency = properties.frequency(qubit)
-        except Exception:
+        except Exception: # pylint: disable=broad-except
             t_2 = None
         try:
             anharmonicity = properties.qubit_property(qubit, "anharmonicity")[0]

--- a/qiskit_ibm_provider/utils/backend_converter.py
+++ b/qiskit_ibm_provider/utils/backend_converter.py
@@ -147,9 +147,18 @@ def qubit_props_list_from_props(
     """
     qubit_props: List[IBMQubitProperties] = []
     for qubit, _ in enumerate(properties.qubits):
-        t_1 = properties.t1(qubit)
-        t_2 = properties.t2(qubit)
-        frequency = properties.frequency(qubit)
+        try:
+            t_1 = properties.t1(qubit)
+        except Exception:
+            t_1 = None
+        try:
+            t_2 = properties.t2(qubit)
+        except Exception:
+            t_2 = None
+        try:
+            frequency = properties.frequency(qubit)
+        except Exception:
+            t_2 = None
         try:
             anharmonicity = properties.qubit_property(qubit, "anharmonicity")[0]
         except Exception:  # pylint: disable=broad-except

--- a/qiskit_ibm_provider/utils/backend_converter.py
+++ b/qiskit_ibm_provider/utils/backend_converter.py
@@ -149,7 +149,7 @@ def qubit_props_list_from_props(
     for qubit, _ in enumerate(properties.qubits):
         try:
             t_1 = properties.t1(qubit)
-        except Exception:
+        except Exception: # pylint: disable=broad-except
             t_1 = None
         try:
             t_2 = properties.t2(qubit)


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit handles and edge case in the Target object generation when
building a backend object. Some backends are missing T1, T2, and
frequency for some (or all) qubits. To handle this edge case we
shouldn't fail if they're missing just simply not populate the
properties on that qubit. These are optional properties and are not
required to build a Target, so if they're missing on the API response
payload we can just exclude them from the output Target object.

### Details and comments