### PR TITLE
Update scheduling passes to group measurements

### DIFF
--- a/qiskit_ibm_provider/transpiler/passes/scheduling/block_base_padder.py
+++ b/qiskit_ibm_provider/transpiler/passes/scheduling/block_base_padder.py
@@ -21,6 +21,8 @@ from qiskit.dagcircuit import DAGCircuit, DAGNode
 from qiskit.transpiler.basepasses import TransformationPass
 from qiskit.transpiler.exceptions import TranspilerError
 
+from .utils import block_order_op_nodes
+
 
 class BlockBasePadder(TransformationPass):
     """The base class of padding pass.
@@ -82,7 +84,7 @@ class BlockBasePadder(TransformationPass):
         # Note that pre-scheduled duration may change within the alignment passes, i.e.
         # if some instruction time t0 violating the hardware alignment constraint,
         # the alignment pass may delay t0 and accordingly the circuit duration changes.
-        for node in dag.topological_op_nodes():
+        for node in block_order_op_nodes(dag):
             if node in self._node_start_time:
                 if isinstance(node.op, Delay):
                     self._visit_delay(node)

--- a/qiskit_ibm_provider/transpiler/passes/scheduling/block_base_padder.py
+++ b/qiskit_ibm_provider/transpiler/passes/scheduling/block_base_padder.py
@@ -188,7 +188,17 @@ class BlockBasePadder(TransformationPass):
         rather than instruction. Delay node is not added so that
         we can extract non-delay predecessors.
         """
-        pass
+        block_idx, t0 = self._node_start_time[node]  # pylint: disable=invalid-name
+        # Trigger the end of a block
+        if block_idx > self._current_block_idx:
+            self._terminate_block(self._block_duration, self._current_block_idx, node)
+
+        self._conditional_block = bool(node.op.condition_bits)
+
+        self._current_block_idx = block_idx
+
+        t1 = t0 + node.op.duration  # pylint: disable=invalid-name
+        self._block_duration = max(self._block_duration, t1)
 
     def _visit_generic(self, node: DAGNode) -> None:
         """Visit a generic node to pad."""

--- a/qiskit_ibm_provider/transpiler/passes/scheduling/scheduler.py
+++ b/qiskit_ibm_provider/transpiler/passes/scheduling/scheduler.py
@@ -21,6 +21,8 @@ from qiskit.dagcircuit import DAGCircuit, DAGNode
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.passes.scheduling.scheduling.base_scheduler import BaseScheduler
 
+from .utils import block_order_op_nodes
+
 
 class DynamicCircuitScheduleAnalysis(BaseScheduler):
     """Dynamic circuits scheduling analysis pass.
@@ -77,7 +79,7 @@ class DynamicCircuitScheduleAnalysis(BaseScheduler):
         """
         self._init_run(dag)
 
-        for node in dag.topological_op_nodes():
+        for node in block_order_op_nodes(dag):
             self._visit_node(node)
 
         self.property_set["node_start_time"] = self._node_start_time

--- a/qiskit_ibm_provider/transpiler/passes/scheduling/scheduler.py
+++ b/qiskit_ibm_provider/transpiler/passes/scheduling/scheduler.py
@@ -61,7 +61,7 @@ class DynamicCircuitScheduleAnalysis(BaseScheduler):
         self._dag = None
 
         self._current_block_idx = 0
-
+        self._conditional_block = False
         self._node_start_time: Optional[Dict[DAGNode, Tuple[int, int]]] = None
         self._idle_after: Optional[Dict[Union[Qubit, Clbit], Tuple[int, int]]] = None
         self._current_block_measures: Set[DAGNode] = set()
@@ -88,6 +88,8 @@ class DynamicCircuitScheduleAnalysis(BaseScheduler):
         """Setup for initial run."""
 
         self._dag = dag
+        self._current_block_idx = 0
+        self._conditional_block = False
 
         if len(dag.qregs) != 1 or dag.qregs.get("q", None) is None:
             raise TranspilerError("ASAP schedule runs on physical circuits only")
@@ -104,13 +106,18 @@ class DynamicCircuitScheduleAnalysis(BaseScheduler):
         # compute t0, t1: instruction interval, note that
         # t0: start time of instruction
         # t1: end time of instruction
-        if isinstance(node.op, self.CONDITIONAL_SUPPORTED):
+        if isinstance(node.op, self.CONDITIONAL_SUPPORTED) and node.op.condition_bits:
             self._visit_conditional_node(node)
         else:
             if node.op.condition_bits:
                 raise TranspilerError(
                     f"Conditional instruction {node.op.name} is not supported in ASAP scheduler."
                 )
+
+            # If True we are coming from a conditional block.
+            # start a new block for the unconditional operations.
+            if self._conditional_block:
+                self._begin_new_circuit_block()
 
             if isinstance(node.op, Measure):
                 self._visit_measure(node)
@@ -131,8 +138,18 @@ class DynamicCircuitScheduleAnalysis(BaseScheduler):
         """
         # Special processing required to resolve conditional scheduling dependencies
         if node.op.condition_bits:
-            # Trigger the start of a conditional block
-            self._begin_new_circuit_block()
+            # We group conditional operations within
+            # a conditional block to allow the backend
+            # a chance to optimize them. If we did
+            # not do this barriers would be inserted
+            # between conditional operations.
+            # Therefore only trigger the start of a conditional
+            # block if we are not already within one.
+            if not self._conditional_block:
+                self._begin_new_circuit_block()
+
+            # This block is now by definition a "conditional_block".
+            self._conditional_block = True
 
             op_duration = self._get_duration(node)
 
@@ -165,9 +182,6 @@ class DynamicCircuitScheduleAnalysis(BaseScheduler):
 
             t1 = t0 + op_duration  # pylint: disable=invalid-name
             self._update_idles(node, t0, t1)
-
-            # Terminate the conditional block
-            self._begin_new_circuit_block()
 
         else:
             # Fall through to generic case if not conditional
@@ -267,6 +281,7 @@ class DynamicCircuitScheduleAnalysis(BaseScheduler):
     def _begin_new_circuit_block(self) -> None:
         """Create a new timed circuit block completing the previous block."""
         self._current_block_idx += 1
+        self._conditional_block = False
         self._current_block_measures = set()
         self._idle_after = {q: (0, 0) for q in self._dag.qubits + self._dag.clbits}
 

--- a/qiskit_ibm_provider/transpiler/passes/scheduling/utils.py
+++ b/qiskit_ibm_provider/transpiler/passes/scheduling/utils.py
@@ -1,0 +1,55 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Utility functions for scheduling passes."""
+
+from typing import Generator
+
+from qiskit.circuit import Measure, Reset
+from qiskit.dagcircuit import DAGCircuit, DAGOpNode
+
+
+def block_order_op_nodes(dag: DAGCircuit) -> Generator[DAGOpNode, None, None]:
+    """Yield nodes such that they are sorted into blocks that they minimize synchronization.
+
+    This should be used when iterating nodes in order to find blocks within the circuit
+    for IBM dynamic circuit hardware
+
+    TODO: The need for this should be mitigated when Qiskit adds better support for
+    blocks and walking them in its program representation.
+    """
+    # Dictionary is used as an ordered set of nodes to process
+    next_nodes = dag.topological_op_nodes()
+    while next_nodes:
+        curr_nodes = next_nodes
+        next_nodes_set = set()
+        next_nodes = []
+        for node in curr_nodes:
+            # If we have added this node to the next set of nodes
+            # skip for now.
+            if node in next_nodes_set:
+                next_nodes.append(node)
+                continue
+            # If we encounter one of these nodes we wish
+            # to only process descendants after processing
+            # all non-descendants first. This ensures
+            # maximize the size of our "basic blocks"
+            # and correspondingly minimize the total
+            # number of blocks
+            if isinstance(node.op, (Reset, Measure)):
+                next_nodes_set |= set(
+                    node
+                    for node in dag.descendants(node)
+                    if isinstance(node, DAGOpNode)
+                )
+
+            yield node

--- a/test/unit/transpiler/passes/scheduling/test_dynamical_decoupling.py
+++ b/test/unit/transpiler/passes/scheduling/test_dynamical_decoupling.py
@@ -507,6 +507,58 @@ class TestPadDynamicalDecoupling(QiskitTestCase):
 
         self.assertEqual(circ1, circ2)
 
+    def test_back_to_back_c_if(self):
+        """Test DD with c_if circuit back to back."""
+
+        dd_sequence = [XGate(), XGate()]
+        pm = PassManager(
+            [
+                DynamicCircuitScheduleAnalysis(self.durations),
+                PadDynamicalDecoupling(self.durations, dd_sequence),
+            ]
+        )
+
+        qc = QuantumCircuit(3, 1)
+        qc.delay(800, 1)
+        qc.x(1).c_if(0, True)
+        qc.x(2).c_if(0, True)
+        qc.delay(1000, 2)
+        qc.x(1)
+
+        qc_dd = pm.run(qc)
+
+        expected = QuantumCircuit(3, 1)
+        expected.delay(800, 0)
+        expected.delay(800, 1)
+        expected.delay(800, 2)
+        expected.barrier()
+        expected.x(1).c_if(0, True)
+        expected.barrier()
+        expected.delay(50, 0)
+        expected.x(1)
+        expected.delay(50, 2)
+        expected.barrier()
+        expected.x(2).c_if(0, True)
+        expected.barrier()
+        expected.delay(225, 0)
+        expected.x(0)
+        expected.delay(450, 0)
+        expected.x(0)
+        expected.delay(225, 0)
+        expected.delay(225, 1)
+        expected.x(1)
+        expected.delay(450, 1)
+        expected.x(1)
+        expected.delay(225, 1)
+        expected.delay(225, 2)
+        expected.x(2)
+        expected.delay(450, 2)
+        expected.x(2)
+        expected.delay(225, 2)
+        expected.barrier()
+
+        self.assertEqual(expected, qc_dd)
+
     def test_dd_c_if(self):
         """Test DD with c_if circuit."""
 
@@ -523,7 +575,7 @@ class TestPadDynamicalDecoupling(QiskitTestCase):
         qc.x(2)
         qc.delay(1000, 1)
         qc.x(1).c_if(0, True)
-        qc.delay(800, 1)
+        qc.delay(8000, 1)
         qc.x(2).c_if(0, True)
         qc.delay(1000, 2)
         qc.x(0)
@@ -546,6 +598,22 @@ class TestPadDynamicalDecoupling(QiskitTestCase):
         expected.delay(50, 2)
         expected.barrier()
         expected.x(1).c_if(0, True)
+        expected.barrier()
+        expected.delay(1975, 0)
+        expected.x(0)
+        expected.delay(3950, 0)
+        expected.x(0)
+        expected.delay(1975, 0)
+        expected.delay(1975, 1)
+        expected.x(1)
+        expected.delay(3950, 1)
+        expected.x(1)
+        expected.delay(1975, 1)
+        expected.delay(1975, 2)
+        expected.x(2)
+        expected.delay(3950, 2)
+        expected.x(2)
+        expected.delay(1975, 2)
         expected.barrier()
         expected.x(2).c_if(0, True)
         expected.barrier()

--- a/test/unit/transpiler/passes/scheduling/test_scheduler.py
+++ b/test/unit/transpiler/passes/scheduling/test_scheduler.py
@@ -522,3 +522,32 @@ class TestSchedulingAndPaddingPass(QiskitTestCase):
         expected.barrier()
 
         self.assertEqual(expected, scheduled)
+
+    def test_grouped_measurements_prior_control_flow(self):
+        """Test that measurements are grouped prior to control-flow"""
+        qc = QuantumCircuit(3, 3)
+        qc.measure(0, 0)
+        qc.measure(1, 1)
+        qc.x(2).c_if(0, 1)
+        qc.x(2).c_if(1, 1)
+        qc.measure(2, 2)
+
+        durations = InstructionDurations([("x", None, 200), ("measure", None, 1000)])
+        pm = PassManager([DynamicCircuitScheduleAnalysis(durations), PadDelay()])
+        scheduled = pm.run(qc)
+
+        expected = QuantumCircuit(3, 3)
+        expected.delay(1000, 2)
+        expected.measure(0, 0)
+        expected.measure(1, 1)
+        expected.barrier()
+        expected.x(2).c_if(0, 1)
+        expected.barrier()
+        expected.x(2).c_if(1, 1)
+        expected.barrier()
+        expected.delay(1000, 0)
+        expected.delay(1000, 1)
+        expected.measure(2, 2)
+        expected.barrier()
+
+        self.assertEqual(expected, scheduled)

--- a/test/unit/transpiler/passes/scheduling/test_scheduler.py
+++ b/test/unit/transpiler/passes/scheduling/test_scheduler.py
@@ -118,7 +118,6 @@ class TestSchedulingAndPaddingPass(QiskitTestCase):
         expected.measure(0, 0)
         expected.barrier()
         expected.x(1).c_if(0, True)
-        expected.barrier()
         expected.x(2).c_if(0, True)
         expected.barrier()
 
@@ -323,9 +322,10 @@ class TestSchedulingAndPaddingPass(QiskitTestCase):
         scheduled = pm.run(qc)
 
         expected = QuantumCircuit(2, 1)
+        expected.delay(100, 0)
+        expected.delay(100, 1)
         expected.barrier()
         expected.x(0).c_if(0, True)
-        expected.barrier()
         expected.x(1).c_if(0, True)
         expected.barrier()
 
@@ -542,7 +542,6 @@ class TestSchedulingAndPaddingPass(QiskitTestCase):
         expected.measure(1, 1)
         expected.barrier()
         expected.x(2).c_if(0, 1)
-        expected.barrier()
         expected.x(2).c_if(1, 1)
         expected.barrier()
         expected.delay(1000, 0)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This addresses the comments from @ajavadia [here](https://github.com/Qiskit/qiskit-ibm-provider/pull/365#issuecomment-1198357262).

This pass also updates the scheduling so as not to place a barrier between conditional operations to enable the backend to have the opportunity to optimize them.

FYI @kdk

### Details and comments


