### PR TITLE
Add transpiler stage plugin for translating c_if to if_else

### DIFF
--- a/qiskit_ibm_provider/transpiler/plugin.py
+++ b/qiskit_ibm_provider/transpiler/plugin.py
@@ -1,0 +1,46 @@
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Plugin for IBM provider backend transpiler stages."""
+
+from typing import Optional
+
+from qiskit.transpiler.passmanager import PassManager
+from qiskit.transpiler.passmanager_config import PassManagerConfig
+from qiskit.transpiler.preset_passmanagers.plugin import PassManagerStagePlugin
+from qiskit.transpiler.preset_passmanagers import common
+from qiskit.transpiler.passes import ConvertConditionsToIfOps
+
+
+class IBMTranslationPlugin(PassManagerStagePlugin):
+    """A translation stage plugin for converting c_if to if_else and then running the basis
+    translator."""
+
+    def pass_manager(
+        self,
+        pass_manager_config: PassManagerConfig,
+        optimization_level: Optional[int] = None
+    ) -> PassManager:
+        """Build IBMTranslationPlugin PassManager."""
+
+        output = PassManager([ConvertConditionsToIfOps()])
+        output += common.generate_translation_passmanager(
+            target=pass_manager_config.target,
+            basis_gates=pass_manager_config.basis_gates,
+            approximation_degree=pass_manager_config.approximation_degree,
+            coupling_map=pass_manager_config.coupling_map,
+            backend_props=pass_manager_config.backend_properties,
+            unitary_synthesis_method=pass_manager_config.unitary_synthesis_method,
+            unitary_synthesis_plugin_config=pass_manager_config.unitary_synthesis_plugin_config,
+            hls_config=pass_manager_config.hls_config
+        )
+        return output

--- a/qiskit_ibm_provider/transpiler/plugin.py
+++ b/qiskit_ibm_provider/transpiler/plugin.py
@@ -28,7 +28,7 @@ class IBMTranslationPlugin(PassManagerStagePlugin):
     def pass_manager(
         self,
         pass_manager_config: PassManagerConfig,
-        optimization_level: Optional[int] = None
+        optimization_level: Optional[int] = None,
     ) -> PassManager:
         """Build IBMTranslationPlugin PassManager."""
 
@@ -41,6 +41,6 @@ class IBMTranslationPlugin(PassManagerStagePlugin):
             backend_props=pass_manager_config.backend_properties,
             unitary_synthesis_method=pass_manager_config.unitary_synthesis_method,
             unitary_synthesis_plugin_config=pass_manager_config.unitary_synthesis_plugin_config,
-            hls_config=pass_manager_config.hls_config
+            hls_config=pass_manager_config.hls_config,
         )
         return output

--- a/setup.py
+++ b/setup.py
@@ -92,4 +92,9 @@ setuptools.setup(
         "Documentation": "https://qiskit.org/documentation/",
         "Source Code": "https://github.com/Qiskit/qiskit-ibm-provider",
     },
+    entry_points={
+        "qiskit.transpiler.translation": [
+            "ibm_dynamic_circuits = qiskit_ibm_provider.transpiler.plugin:IBMTranslationPlugin",
+        ]
+    },
 )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary


This commit adds a new transpiler stage plugin to the ibm provider which is the default basis translator stage with the additional initial step of converting c_if conditionals to if_else instructions in the circuit prior to performing basis translation.

The next step after this is to add a method
`get_translation_stage_plugin` to the `IBMBackend` class and have it return `"ibm_dynamic_circuits"` when we're targeting a dynamic circuits backend [1]. Doing this will mean that by default a user calling `transpile()` will automatically use this plugin when targeting an appropriate IBMBackend. However, this was not included in the PR because it was not clear how to determine the type of backend `self` was (in relation to supporting dynamic circuits or not) and I expect this is likely something being worked on in #408, so we can add this after we determine how we're representing whether a backend object supports dynamic circuits or not.

### Details and comments

[1] https://qiskit.org/documentation/apidoc/providers.html#custom-transpiler-passes

Starts #418