### PR TITLE
[WIP] Pass in options to backend.run()

### DIFF
--- a/qiskit_ibm_provider/__init__.py
+++ b/qiskit_ibm_provider/__init__.py
@@ -86,6 +86,7 @@ from .backendjoblimit import BackendJobLimit
 from .exceptions import *
 from .ibm_backend_service import IBMBackendService
 from .utils.utils import setup_logger
+from .utils.options import DynamicCircuitOptions, StaticCircuitOptions
 from .version import __version__
 
 # Setup the logger for the IBM Quantum Provider package.

--- a/qiskit_ibm_provider/utils/options.py
+++ b/qiskit_ibm_provider/utils/options.py
@@ -21,7 +21,7 @@ from qiskit.qobj.utils import MeasLevel, MeasReturnType
 
 
 @dataclass
-class QASM3Options:
+class DynamicCircuitOptions:
     """Options for the QASM3 path."""
 
     circuits: Union[
@@ -40,7 +40,7 @@ class QASM3Options:
 
 
 @dataclass
-class QASM2Options:
+class StaticCircuitOptions:
     """Options for the QASM2 path."""
 
     circuits: Union[


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Allows users to pass in options directly into `backend.run()`

```python
from qiskit_ibm_provider import DynamicCircuitOptions #maybe the name should just be DynamicOptions?

options = DynamicCircuitOptions(merge_circuits=False)
options.merge_circuits = False  
backend.run(circuits, dynamic=True, options=options)
```

fixes #408 

### Details and comments


