### PR TITLE
Remove test_retrieve_failed_job_simulator_partial

### DIFF
--- a/test/integration/test_ibm_job.py
+++ b/test/integration/test_ibm_job.py
@@ -325,20 +325,6 @@ class TestIBMJob(IBMTestCase):
         )
         self.assertNotIn(job.job_id(), [rjob.job_id() for rjob in oldest_jobs])
 
-    # TODO: check why test case still fails
-    @skip(
-        "Ported from qiskit-ibmq-provider. Test case still skipped even though aer issue 1214 is fixed. "
-        "Needs further investigation"
-    )
-    def test_retrieve_failed_job_simulator_partial(self):
-        """Test retrieving partial results from a simulator backend."""
-        job = submit_job_one_bad_instr(self.sim_backend)
-        result = job.result(partial=True)
-
-        self.assertIsInstance(result, Result)
-        self.assertTrue(result.results[0].success)
-        self.assertFalse(result.results[1].success)
-
     def test_retrieve_from_retired_backend(self):
         """Test retrieving a job from a retired backend."""
         saved_backends = copy.copy(self.provider.backend._backends)

--- a/test/integration/test_ibm_job.py
+++ b/test/integration/test_ibm_job.py
@@ -22,7 +22,6 @@ from dateutil import tz
 from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 from qiskit.compiler import transpile
 from qiskit.providers.jobstatus import JobStatus, JOB_FINAL_STATES
-from qiskit.result import Result
 from qiskit.test.reference_circuits import ReferenceCircuits
 
 from qiskit_ibm_provider import IBMBackend
@@ -43,7 +42,6 @@ from ..utils import (
     most_busy_backend,
     cancel_job,
     submit_and_cancel,
-    submit_job_one_bad_instr,
 )
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Retrieving partial results is not supported 

fixes #178 

### Details and comments


