### PR TITLE
Remove test_retrieve_from_retired_backend

### DIFF
--- a/test/integration/test_ibm_job.py
+++ b/test/integration/test_ibm_job.py
@@ -28,7 +28,6 @@ from qiskit_ibm_provider import IBMBackend
 from qiskit_ibm_provider.api.exceptions import RequestsApiError
 from qiskit_ibm_provider.api.rest.job import Job as RestJob
 from qiskit_ibm_provider.exceptions import IBMBackendApiError
-from qiskit_ibm_provider.ibm_backend import IBMRetiredBackend
 from qiskit_ibm_provider.job.exceptions import IBMJobTimeoutError
 from ..decorators import (
     IntegrationTestDependencies,
@@ -342,25 +341,6 @@ class TestIBMJob(IBMTestCase):
             start_datetime=self.last_month,
         )
         self.assertNotIn(job.job_id(), [rjob.job_id() for rjob in oldest_jobs])
-
-    def test_retrieve_from_retired_backend(self):
-        """Test retrieving a job from a retired backend."""
-        saved_backends = copy.copy(self.provider.backend._backends)
-        try:
-            del self.provider.backend._backends[self.sim_backend.name]
-            new_job = self.provider.backend.retrieve_job(self.sim_job.job_id())
-            self.assertTrue(isinstance(new_job.backend(), IBMRetiredBackend))
-            self.assertNotEqual(new_job.backend().name, "unknown")
-            fifteen_minutes_ago = datetime.now() - timedelta(minutes=15)
-            recent_jobs = self.provider.backend.jobs(
-                limit=None,
-                start_datetime=fifteen_minutes_ago,
-                backend_name=new_job.backend().name,
-            )
-            recent_job_ids = [job.job_id() for job in recent_jobs]
-            self.assertIn(new_job.job_id(), recent_job_ids)
-        finally:
-            self.provider.backend._backends = saved_backends
 
     def test_refresh_job_result(self):
         """Test re-retrieving job result via refresh."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Retrieving jobs from retired backends not supported 

### Details and comments


