### PR TITLE
Use supported_instructions not basis_gates for control flow

### DIFF
--- a/qiskit_ibm_provider/utils/backend_converter.py
+++ b/qiskit_ibm_provider/utils/backend_converter.py
@@ -144,7 +144,7 @@ def convert_to_target(
         )
     # Handle control flow opeartions as globally support in the target
     for control_flow_op_name, op_class in control_flow_map.items():
-        if control_flow_op_name in configuration.basis_gates:
+        if control_flow_op_name in configuration.supported_instructions:
             target.add_instruction(op_class, name=control_flow_op_name)
 
     return target

--- a/qiskit_ibm_provider/utils/backend_converter.py
+++ b/qiskit_ibm_provider/utils/backend_converter.py
@@ -144,7 +144,10 @@ def convert_to_target(
         )
     # Handle control flow opeartions as globally support in the target
     for control_flow_op_name, op_class in control_flow_map.items():
-        if control_flow_op_name in configuration.supported_instructions:
+        if (
+            control_flow_op_name in configuration.supported_instructions
+            or control_flow_op_name in configuration.basis_gates
+        ):
             target.add_instruction(op_class, name=control_flow_op_name)
 
     return target


### PR DESCRIPTION
### Summary

Control-flow already isn't really a basis gate, but due to deployment issues in the short term, it may be more convenient to get `if_else` into `supported_instructions` and not `basis_gates`.  This swaps the check in the `Target` construction over, so it will be respected if so.

For transpiling on Terra, it doesn't matter that `if_else` isn't in basis gates, because the `Target` takes priority.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### Details and comments

cc: @taalexander.

This is just in draft because it _may_ not be necessary, but if it is, then it's ready to go.
