### PR TITLE
Check if supported_instructions exists in configuration

### DIFF
--- a/qiskit_ibm_provider/utils/backend_converter.py
+++ b/qiskit_ibm_provider/utils/backend_converter.py
@@ -145,7 +145,7 @@ def convert_to_target(
     # Handle control flow opeartions as globally support in the target
     for control_flow_op_name, op_class in control_flow_map.items():
         if (
-            control_flow_op_name in configuration.supported_instructions
+            control_flow_op_name in getattr(configuration, "supported_instructions", {})
             or control_flow_op_name in configuration.basis_gates
         ):
             target.add_instruction(op_class, name=control_flow_op_name)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
https://github.com/Qiskit/qiskit-ibm-provider/pull/443 is causing integration tests to fail

```
AttributeError: Attribute supported_instructions is not defined
```

https://github.com/Qiskit/qiskit-ibm-provider/actions/runs/3388751755/jobs/5631809528

### Details and comments


