### PR TITLE
Use qiskitrc credentials if default config doesn't exist

### DIFF
--- a/qiskit_ibm_provider/accounts/storage.py
+++ b/qiskit_ibm_provider/accounts/storage.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 from typing import Optional, Dict
+from configparser import ConfigParser
 from .exceptions import AccountAlreadyExistsError
 
 logger = logging.getLogger(__name__)
@@ -88,3 +89,13 @@ def _ensure_file_exists(filename: str, initial_content: str = "{}") -> None:
         # initialize file
         with open(filename, mode="w", encoding="utf-8") as json_file:
             json_file.write(initial_content)
+
+
+def read_qiskitrc(qiskitrc_config_file: str) -> Dict[str, str]:
+    """Read credentials from a qiskitrc config and return as a dictionary."""
+    config_parser = ConfigParser()
+    config_parser.read(qiskitrc_config_file)
+    account_data = {}
+    for name in config_parser.sections():
+        account_data = dict(config_parser.items(name))
+    return account_data

--- a/qiskit_ibm_provider/ibm_provider.py
+++ b/qiskit_ibm_provider/ibm_provider.py
@@ -214,10 +214,7 @@ class IBMProvider(Provider):
                     logger.warning(
                         "Loading default ibm_quantum account. Input 'url' is ignored."
                     )
-                account = AccountManager.get(channel="ibm_quantum")
-
-        if account is None:
-            account = AccountManager.get()
+                account = AccountManager.get()
 
         if instance:
             account.instance = instance

--- a/releasenotes/notes/load-qiskitrc-28ce9a3791fcc7c1.yaml
+++ b/releasenotes/notes/load-qiskitrc-28ce9a3791fcc7c1.yaml
@@ -1,0 +1,6 @@
+---
+upgrade:
+  - |
+    When initializing :class:`~qiskit_ibm_provider.IBMProvider`, and there are no
+    accounts found, if a qiskitrc file exists, credentials from this file will be saved 
+    as the ``default-ibm-quantum`` account.

--- a/test/account.py
+++ b/test/account.py
@@ -129,6 +129,29 @@ class temporary_account_config_file(ContextDecorator):
         )
 
 
+class custom_qiskitrc(ContextDecorator):
+    """Context manager that uses a temporary qiskitrc."""
+
+    # pylint: disable=invalid-name
+
+    def __init__(self, contents=b""):
+        # Create a temporary file with the contents.
+        self.tmp_file = NamedTemporaryFile()
+        self.tmp_file.write(contents)
+        self.tmp_file.flush()
+        self.default_qiskitrc_file_original = AccountManager._qiskitrc_config_file
+
+    def __enter__(self):
+        # Temporarily modify the default location of the qiskitrc file.
+        AccountManager._qiskitrc_config_file = self.tmp_file.name
+        return self
+
+    def __exit__(self, *exc):
+        # Delete the temporary file and restore the default location.
+        self.tmp_file.close()
+        AccountManager._qiskitrc_config_file = self.default_qiskitrc_file_original
+
+
 def get_account_config_contents(
     name=None,
     channel="ibm_quantum",

--- a/test/unit/test_account.py
+++ b/test/unit/test_account.py
@@ -32,6 +32,7 @@ from ..account import (
     temporary_account_config_file,
     custom_envs,
     no_envs,
+    custom_qiskitrc,
 )
 from ..ibm_test_case import IBMTestCase
 
@@ -483,6 +484,24 @@ class TestEnableAccount(IBMTestCase):
             service = FakeProvider(instance=instance)
         self.assertTrue(service._account)
         self.assertEqual(service._account.instance, instance)
+
+    def test_enable_account_by_qiskitrc(self):
+        """Test initializing account by a qiskitrc file."""
+        token = "token-x"
+        proxies = {"urls": {"https": "localhost:8080"}}
+        str_contents = f"""
+        [ibmq] 
+        token = {token}
+        url = https://auth.quantum-computing.ibm.com/api 
+        verify = True
+        default_provider = ibm-q/open/main
+        proxies = {proxies}
+        """
+        with custom_qiskitrc(contents=str.encode(str_contents)):
+            with temporary_account_config_file(contents={}):
+                service = FakeProvider()
+        self.assertTrue(service._account)
+        self.assertEqual(service._account.token, token)
 
     def _verify_prefs(self, prefs, account):
         if "proxies" in prefs:

--- a/test/unit/test_account.py
+++ b/test/unit/test_account.py
@@ -193,9 +193,7 @@ class TestAccountManager(IBMTestCase):
             name=None,
             overwrite=True,
         )
-        self.assertEqual(
-            _TEST_IBM_QUANTUM_ACCOUNT, AccountManager.get(channel="ibm_quantum")
-        )
+        self.assertEqual(_TEST_IBM_QUANTUM_ACCOUNT, AccountManager.get())
 
     @temporary_account_config_file(
         contents={"conflict": _TEST_IBM_QUANTUM_ACCOUNT.to_saved_format()}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

copying from https://github.com/Qiskit/qiskit-ibm-runtime/pull/370

If the `qiskit-ibm.json` config file doesn't exist or doesn't have any valid accounts, credentials will be copied over from a `qiskitrc` file, given that it exists.

### Details and comments


