### PR TITLE
Add reproducer and warning for Issue 458

### DIFF
--- a/docs/tutorials/Migration_Guide_from_qiskit-ibmq-provider.ipynb
+++ b/docs/tutorials/Migration_Guide_from_qiskit-ibmq-provider.ipynb
@@ -59,11 +59,11 @@
     "# Create a circuit\n",
     "qc = QuantumCircuit(2)\n",
     "qc.h(0)\n",
-    "qc.cx(0,1)\n",
+    "qc.cx(0, 1)\n",
     "qc.measure_all()\n",
     "\n",
     "# Select a backend.\n",
-    "backend = provider.get_backend('ibmq_qasm_simulator')\n",
+    "backend = provider.get_backend(\"ibmq_qasm_simulator\")\n",
     "# Submit a job.\n",
     "job = backend.run(qc)\n",
     "# Get results.\n",
@@ -189,7 +189,7 @@
     "\n",
     "qc = QuantumCircuit(2)\n",
     "qc.h(0)\n",
-    "qc.cx(0,1)\n",
+    "qc.cx(0, 1)\n",
     "qc.measure_all()"
    ]
   },
@@ -211,7 +211,7 @@
     "from qiskit import IBMQ\n",
     "\n",
     "provider = IBMQ.load_account()\n",
-    "backend = provider.get_backend('ibmq_qasm_simulator')\n",
+    "backend = provider.get_backend(\"ibmq_qasm_simulator\")\n",
     "job = backend.run(qc)\n",
     "print(job.result().get_counts())"
    ]
@@ -232,7 +232,7 @@
     "from qiskit_ibm_provider import IBMProvider\n",
     "\n",
     "provider = IBMProvider()\n",
-    "backend = provider.get_backend('ibmq_qasm_simulator')\n",
+    "backend = provider.get_backend(\"ibmq_qasm_simulator\")\n",
     "job = backend.run(qc)\n",
     "print(job.result().get_counts())"
    ]

--- a/qiskit_ibm_provider/transpiler/passes/scheduling/__init__.py
+++ b/qiskit_ibm_provider/transpiler/passes/scheduling/__init__.py
@@ -22,6 +22,10 @@ backends that support advanced "dynamic circuit" capabilities. Ie.,
 circuits with support for classical control-flow/feedback based off
 of measurement results.
 
+.. warning::
+    You should not mix these scheduling passes with Qiskit's builtin scheduling
+    passes as they will negatively interact with the scheduling routines for
+    dynamic circuits. This includes setting ``scheduling_method`` in ``transpile``.
 
 Below we demonstrate how to schedule and pad a teleportation circuit with delays
 for a dynamic circuit backend's execution model:

--- a/releasenotes/notes/fix-alap-scheduling-bug-e00955caf9b96d13.yaml
+++ b/releasenotes/notes/fix-alap-scheduling-bug-e00955caf9b96d13.yaml
@@ -4,5 +4,4 @@ fixes:
     A bug was fixed in
     :class:`qiskit.transpiler.passes.scheduling.LAPScheduleAnalysis`
     which was caused by an bad interaction between duration-less gates
-    such as ``rz`` and ``barrier``s.
-
+    such as ``rz`` and ``barrier``.

--- a/releasenotes/notes/fix-alap-scheduling-bug-e00955caf9b96d13.yaml
+++ b/releasenotes/notes/fix-alap-scheduling-bug-e00955caf9b96d13.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    A bug was fixed in
+    :class:`qiskit.transpiler.passes.scheduling.LAPScheduleAnalysis`
+    which was caused by an bad interaction between duration-less gates
+    such as ``rz`` and ``barrier``s.
+

--- a/test/unit/transpiler/passes/scheduling/test_dynamical_decoupling.py
+++ b/test/unit/transpiler/passes/scheduling/test_dynamical_decoupling.py
@@ -17,7 +17,7 @@ from numpy import pi
 
 from ddt import ddt, data
 from qiskit import pulse
-from qiskit.circuit import QuantumCircuit, Delay, QuantumRegister, ClassicalRegister
+from qiskit.circuit import QuantumCircuit, Delay
 from qiskit.circuit.library import XGate, YGate, RXGate, UGate
 from qiskit.quantum_info import Operator
 from qiskit.test import QiskitTestCase
@@ -28,7 +28,7 @@ from qiskit_ibm_provider.transpiler.passes.scheduling.dynamical_decoupling impor
     PadDynamicalDecoupling,
 )
 from qiskit_ibm_provider.transpiler.passes.scheduling.scheduler import (
-    ALAPScheduleAnalysis, ASAPScheduleAnalysis,
+    ASAPScheduleAnalysis,
 )
 from qiskit_ibm_provider.transpiler.passes.scheduling.utils import (
     DynamicCircuitInstructionDurations,
@@ -814,63 +814,4 @@ class TestPadDynamicalDecoupling(QiskitTestCase):
         expected.delay(450, 0)
         expected.delay(225, 0)
         expected.barrier()
-        self.assertEqual(qc_dd, expected)
-
-    def test_issue_458_extra_idle_bug(self):
-        """Regression test for https://github.com/Qiskit/qiskit-ibm-provider/issues/458"""
-
-        qc = QuantumCircuit(4, 3)
-
-        qc.cx(0,1)
-        qc.delay(200, 0)
-        qc.delay(700, 2)
-        qc.cx(1, 2)
-        qc.delay(3060, 3)
-        qc.barrier([0, 1, 2])
-
-        qc.delay(1160, 0)
-        qc.delay(1000, 2)
-        qc.measure(1, 0)
-        qc.delay(160, 1)
-        qc.x(2).c_if(0, 1)
-        qc.barrier([0, 1, 2])
-        qc.measure(0, 1)
-        qc.delay(1000, 1)
-        qc.measure(2, 2)
-
-        dd_sequence = [
-            [XGate(), XGate()],
-        ]
-
-        pm = PassManager(
-            [
-                ALAPScheduleAnalysis(self.durations),
-                PadDynamicalDecoupling(
-                    self.durations,
-                    dd_sequence,
-                    qubits=[0],
-                    extra_slack_distribution="edges",
-                    pulse_alignment=16,
-                    insert_multiple_cycles=False,
-                ),
-            ]
-        )
-
-        qc_dd = pm.run(qc)
-
-        expected = QuantumCircuit(1, 0)
-        expected.x(0)
-        expected.delay(225, 0)
-        expected.x(0)
-        expected.delay(450, 0)
-        expected.x(0)
-        expected.delay(225, 0)
-        expected.x(0)
-        expected.delay(225, 0)
-        expected.x(0)
-        expected.delay(450, 0)
-        expected.delay(225, 0)
-        expected.barrier()
-
-        import pdb;pdb.set_trace()
         self.assertEqual(qc_dd, expected)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #458. This adds a test reproducing the scheduling interaction found in #458 and adds a warning in documentation to avoid users from mixing the standard Qiskit scheduling with the dynamic circuit scheduling.

### Details and comments


