### PR TITLE
Retrieve old path jobs

### DIFF
--- a/qiskit_ibm_provider/api/clients/account.py
+++ b/qiskit_ibm_provider/api/clients/account.py
@@ -70,3 +70,25 @@ class AccountClient(BaseClient):
             Job information.
         """
         return self.base_api.job(job_id).get()
+
+    def list_jobs(
+        self,
+        limit: int = 10,
+        skip: int = 0,
+        descending: bool = True,
+        extra_filter: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return a list of job data, with filtering and pagination.
+        In order to reduce the amount of data transferred, the server only
+        sends back a subset of the total information for each job.
+        Args:
+            limit: Maximum number of items to return.
+            skip: Offset for the items to return.
+            descending: Whether the jobs should be in descending order.
+            extra_filter: Additional filtering passed to the query.
+        Returns:
+            A list of job data.
+        """
+        return self.base_api.jobs(
+            limit=limit, skip=skip, descending=descending, extra_filter=extra_filter
+        )

--- a/qiskit_ibm_provider/api/clients/account.py
+++ b/qiskit_ibm_provider/api/clients/account.py
@@ -13,6 +13,7 @@
 """Client for accessing an individual IBM Quantum account."""
 
 import logging
+import json
 from typing import List, Dict, Any, Optional
 
 from .base import BaseClient
@@ -92,3 +93,21 @@ class AccountClient(BaseClient):
         return self.base_api.jobs(
             limit=limit, skip=skip, descending=descending, extra_filter=extra_filter
         )
+
+    def job_result(self, job_id: str) -> str:
+        """Retrieve and return the job result.
+        Args:
+            job_id: The ID of the job.
+        Returns:
+            Job result.
+        """
+
+        job_api = self.base_api.job(job_id)
+
+        # Get the download URL.
+        download_url = job_api.result_url()["url"]
+
+        # Download the result from object storage.
+        result_response = job_api.get_object_storage(download_url)
+
+        return json.dumps(result_response)

--- a/qiskit_ibm_provider/api/clients/account.py
+++ b/qiskit_ibm_provider/api/clients/account.py
@@ -17,7 +17,7 @@ from typing import List, Dict, Any, Optional
 
 from .base import BaseClient
 from ..client_parameters import ClientParameters
-from ..rest import Account
+from ..rest import Api, Account
 from ..session import RetrySession
 from ...utils.hgp import from_instance_format
 
@@ -39,6 +39,7 @@ class AccountClient(BaseClient):
         self._params = params
         hub, group, project = from_instance_format(params.instance)
         # base_api is used to handle endpoints that don't include h/g/p.
+        self.base_api = Api(self._session)
         # account_api is for h/g/p.
         self.account_api = Account(
             session=self._session,
@@ -59,3 +60,13 @@ class AccountClient(BaseClient):
             Backends available for this provider.
         """
         return self.account_api.backends(timeout=timeout)
+
+    # Old iqx api
+    def job_get(self, job_id: str) -> Dict[str, Any]:
+        """Return information about the job.
+        Args:
+            job_id: The ID of the job.
+        Returns:
+            Job information.
+        """
+        return self.base_api.job(job_id).get()

--- a/qiskit_ibm_provider/api/clients/runtime.py
+++ b/qiskit_ibm_provider/api/clients/runtime.py
@@ -138,6 +138,17 @@ class RuntimeClient(BaseClient):
         logger.debug("Runtime job get response: %s", response)
         return response
 
+    def job_type(self, job_id: str) -> str:
+        """Get job type.
+
+        Args:
+            job_id: Job ID.
+
+        Returns:
+            Job type, either "IQX" or "RUNTIME".
+        """
+        return self._api.program_job(job_id).job_type()
+
     def jobs_get(
         self,
         limit: int = None,

--- a/qiskit_ibm_provider/api/rest/base.py
+++ b/qiskit_ibm_provider/api/rest/base.py
@@ -43,3 +43,14 @@ class RestAdapterBase:
             The resolved URL of the endpoint (relative to the session base URL).
         """
         return "{}{}".format(self.prefix_url, self.URL_MAP[identifier])
+
+    def get_facade_url(self, facade_prefix: str, identifier: str) -> str:
+        """Return the resolved facade URL for the specified identifier.
+
+        Args:
+            identifier: Internal identifier of the endpoint.
+
+        Returns:
+            The resolved facade URL of the endpoint.
+        """
+        return "{}{}{}".format(facade_prefix, self.prefix_url, self.URL_MAP[identifier])

--- a/qiskit_ibm_provider/api/rest/job.py
+++ b/qiskit_ibm_provider/api/rest/job.py
@@ -34,6 +34,7 @@ class Job(RestAdapterBase):
         "status": "/status",
         "properties": "/properties",
         "delete": "",
+        "result_url": "/resultDownloadUrl",
     }
 
     def __init__(
@@ -107,3 +108,23 @@ class Job(RestAdapterBase):
         """Mark job for deletion."""
         url = self.get_url("delete")
         self.session.delete(url)
+
+    def result_url(self) -> Dict[str, Any]:
+        """Return an object storage URL for downloading results.
+
+        Returns:
+            JSON response.
+        """
+        url = self.get_url("result_url")
+        return self.session.get(url).json()
+
+    def get_object_storage(self, url: str) -> Dict[str, Any]:
+        """Get via object_storage.
+        Args:
+            url: Object storage URL.
+        Returns:
+            JSON response.
+        """
+        logger.debug("Downloading from object storage.")
+        response = self.session.get(url, bare=True, timeout=600).json()
+        return response

--- a/qiskit_ibm_provider/api/rest/program_job.py
+++ b/qiskit_ibm_provider/api/rest/program_job.py
@@ -32,6 +32,7 @@ class ProgramJob(RestAdapterBase):
         "interim_results": "/interim_results",
         "metrics": "/metrics",
         "tags": "/tags",
+        "type": "/type",
     }
 
     def __init__(
@@ -53,6 +54,18 @@ class ProgramJob(RestAdapterBase):
             JSON response.
         """
         return self.session.get(self.get_url("self")).json(cls=RuntimeDecoder)
+
+    def job_type(self) -> str:
+        """Return job type:
+
+        Returns:
+            Job type, either "IQX" or "RUNTIME".
+        """
+        base_url = self.session.base_url
+        self.session.base_url += "/facade/v1"
+        response = self.session.get(self.get_url("type"))
+        self.session.base_url = base_url
+        return json.loads(response.text)["type"]
 
     def delete(self) -> None:
         """Delete program job."""

--- a/qiskit_ibm_provider/api/rest/program_job.py
+++ b/qiskit_ibm_provider/api/rest/program_job.py
@@ -61,10 +61,7 @@ class ProgramJob(RestAdapterBase):
         Returns:
             Job type, either "IQX" or "RUNTIME".
         """
-        base_url = self.session.base_url
-        self.session.base_url += "/facade/v1"
-        response = self.session.get(self.get_url("type"))
-        self.session.base_url = base_url
+        response = self.session.get(self.get_facade_url("/facade/v1", "type"))
         return json.loads(response.text)["type"]
 
     def delete(self) -> None:

--- a/qiskit_ibm_provider/ibm_backend_service.py
+++ b/qiskit_ibm_provider/ibm_backend_service.py
@@ -226,7 +226,7 @@ class IBMBackendService:
             descending: If ``True``, return the jobs in descending order of the job
                 creation date (i.e. newest first) until the limit is reached.
             instance: The provider in the hub/group/project format.
-            legacy: Retrieve jobs run from the deprecated `qiskit-ibmq-provider`.
+            legacy: Filter to only retrieve jobs run from the deprecated `qiskit-ibmq-provider`.
 
         Returns:
             A list of ``IBMJob`` instances.
@@ -336,7 +336,7 @@ class IBMBackendService:
             skip: Starting index for the job retrieval.
             descending: If ``True``, return the jobs in descending order of the job
                 creation date (i.e. newest first) until the limit is reached.
-            legacy: Retrieve jobs run from the deprecated `qiskit-ibmq-provider`.
+            legacy: Filter to only retrieve jobs run from the deprecated `qiskit-ibmq-provider`.
 
         Returns:
             A list of raw API response.
@@ -386,7 +386,7 @@ class IBMBackendService:
             job_info: Job info in dictionary format.
             raise_error: Whether to raise an exception if `job_info` is in
                 an invalid format.
-            legacy: Retrieve jobs run from the deprecated `qiskit-ibmq-provider`.
+            legacy: Filter to only retrieve jobs run from the deprecated `qiskit-ibmq-provider`.
 
         Returns:
             Circuit job restored from the data, or ``None`` if format is invalid.

--- a/qiskit_ibm_provider/ibm_backend_service.py
+++ b/qiskit_ibm_provider/ibm_backend_service.py
@@ -226,7 +226,8 @@ class IBMBackendService:
             descending: If ``True``, return the jobs in descending order of the job
                 creation date (i.e. newest first) until the limit is reached.
             instance: The provider in the hub/group/project format.
-            legacy: Filter to only retrieve jobs run from the deprecated `qiskit-ibmq-provider`.
+            legacy: If ``True``, only retrieve jobs run from the deprecated ``qiskit-ibmq-provider``.
+            Otherwise, only retrieve jobs run from ``qiskit-ibm-provider``.
 
         Returns:
             A list of ``IBMJob`` instances.

--- a/qiskit_ibm_provider/ibm_backend_service.py
+++ b/qiskit_ibm_provider/ibm_backend_service.py
@@ -296,9 +296,11 @@ class IBMBackendService:
                 break
             for job_info in job_responses:
                 if filter_by_status:
-                    job_status = api_status_to_job_status(
-                        job_info["state"]["status"].upper()
-                    ).name
+                    if legacy:
+                        job_info_status = job_info["status"].upper()
+                    else:
+                        job_info_status = job_info["state"]["status"].upper()
+                    job_status = api_status_to_job_status(job_info_status).name
                     if (isinstance(status, str) and job_status != status) or (
                         isinstance(status, list) and job_status not in status
                     ):

--- a/qiskit_ibm_provider/ibm_provider.py
+++ b/qiskit_ibm_provider/ibm_provider.py
@@ -570,6 +570,7 @@ class IBMProvider(Provider):
         job_tags: Optional[List[str]] = None,
         descending: bool = True,
         instance: Optional[str] = None,
+        legacy: bool = False,
     ) -> List[IBMJob]:
         """Return a list of jobs, subject to optional filtering.
 
@@ -594,6 +595,7 @@ class IBMProvider(Provider):
             descending: If ``True``, return the jobs in descending order of the job
                 creation date (i.e. newest first) until the limit is reached.
             instance: The provider in the hub/group/project format.
+            legacy: Retrieve jobs run from the deprecated `qiskit-ibmq-provider`.
 
         Returns:
             A list of ``IBMJob`` instances.
@@ -610,6 +612,7 @@ class IBMProvider(Provider):
             job_tags=job_tags,
             descending=descending,
             instance=instance,
+            legacy=legacy,
         )
 
     def retrieve_job(self, job_id: str) -> IBMJob:

--- a/qiskit_ibm_provider/ibm_provider.py
+++ b/qiskit_ibm_provider/ibm_provider.py
@@ -595,7 +595,8 @@ class IBMProvider(Provider):
             descending: If ``True``, return the jobs in descending order of the job
                 creation date (i.e. newest first) until the limit is reached.
             instance: The provider in the hub/group/project format.
-            legacy: Retrieve jobs run from the deprecated `qiskit-ibmq-provider`.
+            legacy: If ``True``, only retrieve jobs run from the deprecated ``qiskit-ibmq-provider``.
+            Otherwise, only retrieve jobs run from ``qiskit-ibm-provider``.
 
         Returns:
             A list of ``IBMJob`` instances.

--- a/qiskit_ibm_provider/job/ibm_circuit_job.py
+++ b/qiskit_ibm_provider/job/ibm_circuit_job.py
@@ -681,7 +681,10 @@ class IBMCircuitJob(IBMJob):
 
         if not self._result or refresh:  # type: ignore[has-type]
             try:
-                api_result = self._runtime_client.job_results(self.job_id())
+                if self._provider._runtime_client.job_type(self.job_id()) == "IQX":
+                    api_result = self._api_client.job_result(self.job_id())
+                else:
+                    api_result = self._runtime_client.job_results(self.job_id())
                 self._set_result(api_result)
             except ApiError as err:
                 if self._status not in (JobStatus.ERROR, JobStatus.CANCELLED):

--- a/qiskit_ibm_provider/visualization/interactive/plotly_wrapper.py
+++ b/qiskit_ibm_provider/visualization/interactive/plotly_wrapper.py
@@ -17,7 +17,7 @@ from typing import Tuple, Optional, Any
 
 import plotly.graph_objects as go
 
-
+# pylint: disable=abstract-method
 class PlotlyFigure:
     """A simple wrapper around ``plotly.graph_objects.Figure`` class.
 

--- a/releasenotes/notes/retrieve-legacy-jobs-8ad63f759fe82ac8.yaml
+++ b/releasenotes/notes/retrieve-legacy-jobs-8ad63f759fe82ac8.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    Users can now retrieve jobs run from the previous provider, ``qiskit-ibmq-provider`` with
+    :meth:`~qiskit_ibm_provider.IBMBackendService.retrieve_job`. 
+    There is also a new ``legacy`` parameter in :meth:`~qiskit_ibm_provider.IBMBackendService.jobs` 
+    for retrieving these jobs in bulk.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,3 +28,4 @@ coverage>=6.3
 scikit-learn>=0.20.0
 ddt>=1.2.0,!=1.4.0,!=1.4.3
 pylatexenc>=1.4
+qiskit-ibmq-provider>=0.19.2

--- a/test/integration/test_ibm_job.py
+++ b/test/integration/test_ibm_job.py
@@ -138,6 +138,37 @@ class TestIBMJob(IBMTestCase):
         for job in job_list:
             self.assertTrue(isinstance(job.job_id(), str))
 
+    def test_retrieve_legacy_jobs(self):
+        """Test retrieving legacy jobs."""
+        job_list = self.provider.backend.jobs(
+            backend_name=self.sim_backend.name,
+            status="DONE",
+            limit=5,
+            skip=0,
+            legacy=True,
+        )
+        # instance used may not have any legacy jobs
+        for job in job_list:
+            self.assertTrue(isinstance(job.job_id(), str))
+            self.assertEqual(job.status(), JobStatus.DONE)
+            self.assertTrue(job.result())
+
+    def test_retrieve_single_legacy_job(self):
+        """Test retrieving a single legacy job."""
+        job_list = self.provider.backend.jobs(
+            backend_name=self.sim_backend.name,
+            status="DONE",
+            limit=1,
+            skip=0,
+            legacy=True,
+        )
+
+        # instance used may not have any legacy jobs
+        if len(job_list) == 1:
+            job = job_list[0]
+            retrieved_job = self.provider.backend.retrieve_job(job.job_id())
+            self.assertEqual(job.job_id(), retrieved_job.job_id())
+
     def test_retrieve_jobs_with_status(self):
         """Test retreiving jobs with status filter."""
         statuses = [["DONE"], JobStatus.DONE, [JobStatus.DONE]]

--- a/test/integration/test_ibm_job.py
+++ b/test/integration/test_ibm_job.py
@@ -24,6 +24,7 @@ from qiskit.compiler import transpile
 from qiskit.providers.jobstatus import JobStatus, JOB_FINAL_STATES
 from qiskit.test.reference_circuits import ReferenceCircuits
 
+from qiskit import IBMQ
 from qiskit_ibm_provider import IBMBackend
 from qiskit_ibm_provider.api.exceptions import RequestsApiError
 from qiskit_ibm_provider.api.rest.job import Job as RestJob
@@ -53,7 +54,6 @@ class TestIBMJob(IBMTestCase):
         """Initial class level setup."""
         # pylint: disable=arguments-differ
         super().setUpClass()
-
         cls.provider = dependencies.provider
         cls.sim_backend = dependencies.provider.get_backend(
             "ibmq_qasm_simulator", instance=dependencies.instance
@@ -63,6 +63,7 @@ class TestIBMJob(IBMTestCase):
         cls.bell = transpile(ReferenceCircuits.bell(), cls.sim_backend)
         cls.sim_job = cls.sim_backend.run(cls.bell)
         cls.last_month = datetime.now() - timedelta(days=30)
+        cls.legacy_provider = IBMQ.enable_account(dependencies.token)
 
     def test_run_multiple_simulator(self):
         """Test running multiple jobs in a simulator."""
@@ -140,34 +141,33 @@ class TestIBMJob(IBMTestCase):
 
     def test_retrieve_legacy_jobs(self):
         """Test retrieving legacy jobs."""
+        # run jobs from qiskit_ibmq_provider
+        backend_name = "ibmq_qasm_simulator"
+        backend = self.legacy_provider.get_backend(backend_name)
+        job1 = backend.run(ReferenceCircuits.bell())
+        job2 = backend.run(ReferenceCircuits.bell())
+        self.assertTrue(job1.result())
+        self.assertTrue(job2.result())
+
         job_list = self.provider.backend.jobs(
-            backend_name=self.sim_backend.name,
-            status="DONE",
+            backend_name=backend_name,
             limit=5,
             skip=0,
             legacy=True,
         )
-        # instance used may not have any legacy jobs
-        for job in job_list:
-            self.assertTrue(isinstance(job.job_id(), str))
-            self.assertEqual(job.status(), JobStatus.DONE)
-            self.assertTrue(job.result())
+        job_ids = [job.job_id() for job in job_list]
+        self.assertTrue(job1.job_id() in job_ids)
+        self.assertTrue(job2.job_id() in job_ids)
 
     def test_retrieve_single_legacy_job(self):
         """Test retrieving a single legacy job."""
-        job_list = self.provider.backend.jobs(
-            backend_name=self.sim_backend.name,
-            status="DONE",
-            limit=1,
-            skip=0,
-            legacy=True,
-        )
+        # run job from qiskit_ibmq_provider
+        backend = self.legacy_provider.get_backend("ibmq_qasm_simulator")
+        job = backend.run(ReferenceCircuits.bell())
 
-        # instance used may not have any legacy jobs
-        if len(job_list) == 1:
-            job = job_list[0]
-            retrieved_job = self.provider.backend.retrieve_job(job.job_id())
-            self.assertEqual(job.job_id(), retrieved_job.job_id())
+        retrieved_job = self.provider.backend.retrieve_job(job.job_id())
+        self.assertEqual(job.job_id(), retrieved_job.job_id())
+        self.assertTrue(job.result())
 
     def test_retrieve_jobs_with_status(self):
         """Test retreiving jobs with status filter."""

--- a/test/unit/test_ibm_job_states.py
+++ b/test/unit/test_ibm_job_states.py
@@ -522,6 +522,11 @@ class BaseFakeAPI:
             "status_msg": "active",
         }
 
+    def job_type(self, job_id: str) -> str:
+        if job_id[0] != "c" and len(job_id) == 24:
+            return "IQX"
+        return "RUNTIME"
+
 
 class UnknownStatusAPI(BaseFakeAPI):
     """Class for emulating an API with unknown status codes."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Use facade endpoint to check for job type then use appropriate api

```python 
provider.retrieve_job('ce4fo3nach21afprqqcg')
provider.retrieve_job('63877c3392dadc55e2199c48')

# Returns
<IBMCircuitJob('ce4fo3nach21afprqqcg')>
<IBMCircuitJob('63877c3392dadc55e2199c48')>

provider.jobs(legacy=True)

# Returns
[<IBMCircuitJob('638e9c752671e989cc7b0f15')>,
 <IBMCircuitJob('638e9c7097fb57473df21c7c')>,
 <IBMCircuitJob('638e9c68285f59a7f32d1234')>,
 <IBMCircuitJob('638e9c623a35305c00929a18')>, 
# etc... 

```

~~This should not be merged until the facade endpoint is live on production, currently only live on staging~~ 
### Details and comments


