### PR TITLE
Some suggestions for the migration guide

### DIFF
--- a/docs/tutorials/Migration_Guide_from_qiskit-ibmq-provider.ipynb
+++ b/docs/tutorials/Migration_Guide_from_qiskit-ibmq-provider.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Migration guide from qiskit-ibmq-provider to qiskit-ibm-proivder"
+    "# Migration guide from qiskit-ibmq-provider to qiskit-ibm-provider"
    ]
   },
   {
@@ -104,7 +104,7 @@
    "source": [
     "## Initializing an account\n",
     "\n",
-    "When using `qiskit-ibmq-proivder`, one usually manages accounts and gets a provider using the `IBMQ` global variable. In `qiskit-ibm-provider` the provider is created using the `IBMProvider` class.\n",
+    "When using `qiskit-ibmq-provider`, one usually manages accounts and gets a provider using the `IBMQ` global variable. In `qiskit-ibm-provider` the provider is created using the `IBMProvider` class.\n",
     "\n",
     "**Previously:**"
    ]

--- a/docs/tutorials/Migration_Guide_from_qiskit-ibmq-provider.ipynb
+++ b/docs/tutorials/Migration_Guide_from_qiskit-ibmq-provider.ipynb
@@ -16,14 +16,13 @@
     "\n",
     "`qiskit-ibmq-provider` was the original implementation of the `Provider` interface in `qiskit-terra` and the main entry point for accessing IBM Quantum’s systems, simulators, and services. As IBM Quantum expanded, different disjoint services were added to `qiskit-ibmq-provider`, often causing confusion among users, and making new features difficult to find. \n",
     "\n",
-    "With the introduction of [Qiskit Runtime](https://qiskit.org/documentation/partners/qiskit_ibm_runtime/), we decided it was time to restructure the provider:\n",
+    "With the introduction of [Qiskit Runtime](https://quantum-computing.ibm.com/lab/docs/iql/runtime/), we decided it was time to restructure the provider:\n",
     "\n",
-    "- The \"backend\" service (`provider.backend` in the original repo), is replaced by this [qiskit-ibm-provider](https://github.com/Qiskit/qiskit-ibm-provider) repo. It has a similar interface as the original `qiskit-ibmq-provider` (with `ibm-` instead of `ibmq-`) and gives direct access to the quantum hardware. If you need lower-level access to do experiments like device characterization or to research new error correction routines, `qiskit-ibm-provider` is more suitable for you. \n",
-    "- The Qiskit Runtime service (`provider.runtime` in the original repo), goes into [qiskit-ibm-runtime](https://github.com/Qiskit/qiskit-ibm-runtime). It provides access to managed services through the Qiskit Runtime primitives which are integrated with the latest quantum computing technologies, such as error  mitigation and correction. If you prefer getting high quality probability distribution or expectation values without having to optimize the circuits yourself, you may want to start here. \n",
-    "- The experiment service (`provider.experiment` in the original repo) goes into [qiskit-ibm-experiment](https://github.com/Qiskit/qiskit-ibm-experiment).\n",
-    "- The random number generation service (`provider.random` in the original repo) is deprecated. \n",
+    "- The access to backend services (most of the submodules in the previous `qiskit.providers.ibmq`), is replaced by this [qiskit-ibm-provider](https://pypi.org/project/qiskit-ibm-provider/) package. It has a similar interface as the original `qiskit-ibmq-provider` (with `ibm-` instead of `ibmq-`) and gives direct access to the [IBM Quantum compute resources](https://quantum-computing.ibm.com/services/resources). If you need lower-level access to do experiments like device characterization or to research new error correction routines, `qiskit-ibm-provider` is more suitable for you. \n",
+    "- The access to Qiskit Runtime service (formally in `qiskit.providers.ibmq.runtime`), goes into [qiskit-ibm-runtime](https://pypi.org/project/qiskit-ibm-runtime/). It provides access to managed services through the Qiskit Runtime primitives which are integrated with the latest quantum computing technologies, such as error  mitigation and correction. If you prefer getting high quality probability distribution or expectation values without having to optimize the circuits yourself, you may want to start here. \n",
+    "- The access to the experiment service (formally in `qiskit.providers.ibmq.experiment`) goes into [qiskit-ibm-experiment](https://pypi.org/project/qiskit-ibm-experiment/).\n",
     "\n",
-    "This migration guide focuses on moving from `qiskit-ibmq-provider` to `qiskit-ibm-provider`. "
+    "This migration guide focuses on moving from `qiskit-ibmq-provider` to `qiskit-ibm-provider`. For the rest of the migration guide, check "
    ]
   },
   {
@@ -283,9 +282,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "qiskit_provider",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "qiskit_provider"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/docs/tutorials/Migration_Guide_from_qiskit-ibmq-provider.ipynb
+++ b/docs/tutorials/Migration_Guide_from_qiskit-ibmq-provider.ipynb
@@ -14,7 +14,7 @@
     "\n",
     "## Background\n",
     "\n",
-    "`qiskit-ibmq-provider` was the original implementation of the `Provider` interface in `qiskit-terra` and the main entry point for accessing IBM Quantum’s systems, simulators, and services. As IBM Quantum expanded, different disjoint services were added to `qiskit-ibmq-provider`, often causing confusion among users and making new features difficult to find. \n",
+    "`qiskit-ibmq-provider` was the original implementation of the `Provider` interface in `qiskit-terra` and the main entry point for accessing IBM Quantum’s systems, simulators, and services. As IBM Quantum expanded, different disjoint services were added to `qiskit-ibmq-provider`, often causing confusion among users, and making new features difficult to find. \n",
     "\n",
     "With the introduction of [Qiskit Runtime](https://qiskit.org/documentation/partners/qiskit_ibm_runtime/), we decided it was time to restructure the provider:\n",
     "\n",

--- a/docs/tutorials/Migration_Guide_from_qiskit-ibmq-provider.ipynb
+++ b/docs/tutorials/Migration_Guide_from_qiskit-ibmq-provider.ipynb
@@ -18,7 +18,7 @@
     "\n",
     "With the introduction of [Qiskit Runtime](https://qiskit.org/documentation/partners/qiskit_ibm_runtime/), we decided it was time to restructure the provider:\n",
     "\n",
-    "- The \"backend\" service (`provider.backend` in the original repo), is replaced by this [qiskit-ibm-provider](https://github.com/Qiskit/qiskit-ibm-provider) repo. It has a similar interface as the original `qiskit-ibmq-provider` (with `ibm-` instead of `ibmq-`) and gives direct access to the quantum hardware. If you need lower level access to do experiments like device characterization or to research new error correction routines, `qiskit-ibm-provider` is more suitable for you. \n",
+    "- The \"backend\" service (`provider.backend` in the original repo), is replaced by this [qiskit-ibm-provider](https://github.com/Qiskit/qiskit-ibm-provider) repo. It has a similar interface as the original `qiskit-ibmq-provider` (with `ibm-` instead of `ibmq-`) and gives direct access to the quantum hardware. If you need lower-level access to do experiments like device characterization or to research new error correction routines, `qiskit-ibm-provider` is more suitable for you. \n",
     "- The Qiskit Runtime service (`provider.runtime` in the original repo), goes into [qiskit-ibm-runtime](https://github.com/Qiskit/qiskit-ibm-runtime). It provides access to managed services through the Qiskit Runtime primitives which are integrated with the latest quantum computing technologies, such as error  mitigation and correction. If you prefer getting high quality probability distribution or expectation values without having to optimize the circuits yourself, you may want to start here. \n",
     "- The experiment service (`provider.experiment` in the original repo) goes into [qiskit-ibm-experiment](https://github.com/Qiskit/qiskit-ibm-experiment).\n",
     "- The random number generation service (`provider.random` in the original repo) is deprecated. \n",
@@ -162,7 +162,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Loading account from enviornment variables\n",
+    "## Loading account from environment variables\n",
     "\n",
     "The environment variables used for account credentials have changed:\n",
     "\n",
@@ -197,7 +197,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The basic flow of getting a backend, running the circuit using it, getting a job and obtaining the job results is the same.\n",
+    "The basic flow of getting a backend, running the circuit using it, getting a job, and obtaining the job results is the same.\n",
     "\n",
     "**Previously:**"
    ]

--- a/docs/tutorials/Migration_Guide_from_qiskit-ibmq-provider.ipynb
+++ b/docs/tutorials/Migration_Guide_from_qiskit-ibmq-provider.ipynb
@@ -22,7 +22,7 @@
     "- The access to Qiskit Runtime service (formally in `qiskit.providers.ibmq.runtime`), goes into [qiskit-ibm-runtime](https://pypi.org/project/qiskit-ibm-runtime/). It provides access to managed services through the Qiskit Runtime primitives which are integrated with the latest quantum computing technologies, such as error  mitigation and correction. If you prefer getting high quality probability distribution or expectation values without having to optimize the circuits yourself, you may want to start here. \n",
     "- The access to the experiment service (formally in `qiskit.providers.ibmq.experiment`) goes into [qiskit-ibm-experiment](https://pypi.org/project/qiskit-ibm-experiment/).\n",
     "\n",
-    "This migration guide focuses on moving from `qiskit-ibmq-provider` to `qiskit-ibm-provider`. For the rest of the migration guide, check "
+    "This migration guide focuses on moving from `qiskit-ibmq-provider` to `qiskit-ibm-provider`. For the rest of the migration guides, check https://github.com/Qiskit/qiskit-ibmq-provider#migration%20guides "
    ]
   },
   {


### PR DESCRIPTION
This PR goes on top of #466 

This are some suggestions to improve the `Background` section:
 * As Qiskit Runtime is an IBM service, link to the IBM website explaining the service
 * Link to pypi packages instead of github repos, as user can access the source code from that page if they prefer
 * Refer to the modules as `qiskit.providers...` as user probably have that in their code
 * Remove the _random number generation service_ reference, as it is deprecated for a year already and it might be confusing.