### PR TITLE
Enable id->delay translation on all backends

### DIFF
--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -767,8 +767,6 @@ class IBMBackend(Backend):
         # Make sure we don't mutate user's input circuits
         circuits = copy.deepcopy(circuits)
         # Convert id gates to delays.
-        # TODO: This should be part of user-level transpilation
-        # (But we need this to always run. Not just opt-in in plugin)
         pm = PassManager(  # pylint: disable=invalid-name
             ConvertIdToDelay(self._target.durations())
         )
@@ -776,7 +774,7 @@ class IBMBackend(Backend):
 
         return circuits
 
-    def get_translation_stage_plugin(self):
+    def get_translation_stage_plugin(self) -> str:
         """Return the default translation stage plugin name for IBM backends."""
         return "ibm_backend"
 

--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -776,6 +776,9 @@ class IBMBackend(Backend):
 
         return circuits
 
+    def get_translation_stage_plugin(self):
+        return "ibm_backend"
+
 
 class IBMRetiredBackend(IBMBackend):
     """Backend class interfacing with an IBM Quantum device no longer available."""

--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -777,6 +777,7 @@ class IBMBackend(Backend):
         return circuits
 
     def get_translation_stage_plugin(self):
+        """Return the default translation stage plugin name for IBM backends."""
         return "ibm_backend"
 
 

--- a/qiskit_ibm_provider/transpiler/passes/basis/convert_id_to_delay.py
+++ b/qiskit_ibm_provider/transpiler/passes/basis/convert_id_to_delay.py
@@ -51,6 +51,7 @@ class ConvertIdToDelay(TransformationPass):
         """Run the pass on one :class:`.DAGCircuit`, mutating it.  Returns ``True`` if the circuit
         was modified and ``False`` if not."""
         modified = False
+        qubit_index_map = {bit: index for index, bit in enumerate(dag.qubits)}
         for node in dag.op_nodes():
             if isinstance(node.op, ControlFlowOp):
                 modified_blocks = False
@@ -67,7 +68,7 @@ class ConvertIdToDelay(TransformationPass):
                     inplace=True,
                 )
             elif isinstance(node.op, IGate):
-                delay_op = Delay(self._get_duration(node.qargs[0].index))
+                delay_op = Delay(self._get_duration(qubit_index_map[node.qargs[0]]))
                 delay_op.condition = node.op.condition
                 dag.substitute_node(node, delay_op, inplace=True)
 

--- a/qiskit_ibm_provider/transpiler/plugin.py
+++ b/qiskit_ibm_provider/transpiler/plugin.py
@@ -47,6 +47,36 @@ class IBMTranslationPlugin(PassManagerStagePlugin):
             hls_config=pass_manager_config.hls_config,
         )
 
+        plugin_passes = []
+        instruction_durations = pass_manager_config.instruction_durations
+        if instruction_durations:
+            plugin_passes.append(ConvertIdToDelay(instruction_durations))
+
+        return PassManager(plugin_passes) + translator_pm
+
+
+class IBMDynamicTranslationPlugin(PassManagerStagePlugin):
+    """A translation stage plugin for targeting Qiskit circuits
+    to IBM Quantum systems."""
+
+    def pass_manager(
+        self,
+        pass_manager_config: PassManagerConfig,
+        optimization_level: Optional[int] = None,
+    ) -> PassManager:
+        """Build IBMTranslationPlugin PassManager."""
+
+        translator_pm = common.generate_translation_passmanager(
+            target=pass_manager_config.target,
+            basis_gates=pass_manager_config.basis_gates,
+            approximation_degree=pass_manager_config.approximation_degree,
+            coupling_map=pass_manager_config.coupling_map,
+            backend_props=pass_manager_config.backend_properties,
+            unitary_synthesis_method=pass_manager_config.unitary_synthesis_method,
+            unitary_synthesis_plugin_config=pass_manager_config.unitary_synthesis_plugin_config,
+            hls_config=pass_manager_config.hls_config,
+        )
+
         instruction_durations = pass_manager_config.instruction_durations
         plugin_passes = []
         if instruction_durations:

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,8 @@ setuptools.setup(
     },
     entry_points={
         "qiskit.transpiler.translation": [
-            "ibm_dynamic_circuits = qiskit_ibm_provider.transpiler.plugin:IBMTranslationPlugin",
+            "ibm_backend = qiskit_ibm_provider.transpiler.plugin:IBMTranslationPlugin",
+            "ibm_dynamic_circuits = qiskit_ibm_provider.transpiler.plugin:IBMDynamicTranslationPlugin",
         ]
     },
 )

--- a/test/integration/test_backend.py
+++ b/test/integration/test_backend.py
@@ -15,7 +15,7 @@
 from unittest import SkipTest, mock, skip
 from unittest.mock import patch
 
-from qiskit import QuantumCircuit
+from qiskit import QuantumCircuit, transpile
 from qiskit.providers.models import QasmBackendConfiguration
 from qiskit.test.reference_circuits import ReferenceCircuits
 
@@ -156,3 +156,13 @@ class TestIBMBackend(IBMTestCase):
 
             self.assertEqual(mutated_circuit[0].count_ops(), {"delay": 3})
             self.assertEqual(circuit_with_id.count_ops(), {"id": 3})
+
+    def test_transpile_converts_id(self):
+        """Test that when targeting an IBM backend id is translated to delay."""
+        circ = QuantumCircuit(2)
+        circ.id(0)
+        circ.id(1)
+        tqc = transpile(circ, self.backend)
+        op_counts = tqc.count_ops()
+        self.assertNotIn("id", op_counts)
+        self.assertIn("delay", op_counts)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The use of id as a gate equivalent to the single qubit gate delay on IBM backends has been deprecated for > 1 yr. As new backends are being released that do not support using id in this manner anymore we should be translating the id for IBM backends to the delay during transpilation otherwise users who manually insert id into their circuit on new backends without id as a supported gate will get a error. Additionally, Qiskit 0.23.0 will likely change the definition of IGate to be a typical identity which will be optimized away (or translated to Rz(0) if no optimization is specified) which will break user assumptions if they were manually using Id as a single qubit gate delay.

This commit enables default translation during transpile() by creating a separate translation stage plugin which is the default basis translation with the ConvertIdToDelay prepended to it. This plugin is then set as the default with the IBMBackend class using the backend default stage plugin hook points which override the default stage plugin to use during transplation when targeting the backend. This means if a user runs transpile() targeting an IBMBackend object on a cirucit that contains id gate it will be translated to delay as part of that process.


### Details and comments