### PR TITLE
IBMProvider.instances to list list available instances

### DIFF
--- a/qiskit_ibm_provider/ibm_provider.py
+++ b/qiskit_ibm_provider/ibm_provider.py
@@ -430,6 +430,14 @@ class IBMProvider(Provider):
         active_account_dict.update({"instance": hgps[0].name})
         return active_account_dict
 
+    def instances(self) -> List[str]:
+        """Return the IBM Quantum instances list currently in use for the session.
+
+        Returns:
+            A list with instances currently in the session.
+        """
+        return [hgp.name for hgp in self._get_hgps()]
+
     @staticmethod
     def delete_account(name: Optional[str] = None) -> bool:
         """Delete a saved account from disk.

--- a/releasenotes/notes/IBMProvider_instances-e4923ede7198977e.yaml
+++ b/releasenotes/notes/IBMProvider_instances-e4923ede7198977e.yaml
@@ -1,4 +1,4 @@
 ---
 features:
   - |
-    The meth:`~IBMProvider.instances` was added to list all the available instances in a provider instance.
+    The meth:`~qiskit_ibm_provider.IBMProvider.instances` was added to list all the available instances in a provider instance.

--- a/releasenotes/notes/IBMProvider_instances-e4923ede7198977e.yaml
+++ b/releasenotes/notes/IBMProvider_instances-e4923ede7198977e.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    The meth:`~IBMProvider.instances` was added to list all the available instances in a provider instance.

--- a/test/integration/test_ibm_provider.py
+++ b/test/integration/test_ibm_provider.py
@@ -173,6 +173,11 @@ class TestIBMProviderServices(IBMTestCase):
         backends = self.dependencies.provider.backends()
         self.assertTrue(len(backends) > 0)
 
+    def test_instances(self):
+        """Test the provider has instances."""
+        instances = self.dependencies.provider.instances()
+        self.assertTrue(len(instances) > 0)
+
     def test_jobs(self):
         """Test accessing jobs directly from the provider."""
         jobs = self.dependencies.provider.jobs()


### PR DESCRIPTION
### Summary

While debugging #474, I realize that I need list all my instances/HGP. This PR adds the method instances to list available instances in a provider.

```python
from qiskit_ibm_provider import IBMProvider
provider = IBMProvider(instance='ibm-q/open/main')
provider.instances()
```
```
['ibm-q/open/main',
  ...]
```

