### PR TITLE
Fix filtering jobs by instance

### DIFF
--- a/qiskit_ibm_provider/ibm_backend_service.py
+++ b/qiskit_ibm_provider/ibm_backend_service.py
@@ -33,6 +33,7 @@ from .hub_group_project import HubGroupProject
 from .ibm_backend import IBMBackend, IBMRetiredBackend
 from .job import IBMJob, IBMCircuitJob
 from .job.exceptions import IBMJobNotFoundError
+from .utils.hgp import from_instance_format
 from .utils.converters import local_to_utc
 from .utils.utils import (
     to_python_identifier,
@@ -271,7 +272,10 @@ class IBMBackendService:
             validate_job_tags(job_tags, IBMBackendValueError)
             api_filter["job_tags"] = job_tags
         if instance:
-            api_filter["provider"] = instance
+            hub, group, project = from_instance_format(instance)
+            api_filter["hub"] = hub
+            api_filter["group"] = group
+            api_filter["project"] = project
         # Retrieve all requested jobs.
         filter_by_status = (
             status

--- a/releasenotes/notes/jobs-instance-filter-4055aa7a097585c6.yaml
+++ b/releasenotes/notes/jobs-instance-filter-4055aa7a097585c6.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed an issue where filtering by instance with
+    :meth:`~qiskit_ibm_provider.IBMBackendService.jobs` was not working correctly.
+


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`provider.backend.jobs(instance="...")` was not working - hub, group, and project should be used in the `api_filter` dict instead of provider

### Details and comments


