### PR TITLE
Add translation stage to IBM backend and update DD to use

### DIFF
--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -325,14 +325,6 @@ class IBMBackend(Backend):
         self._convert_to_target()
         return self._target
 
-    def get_translation_stage_plugin(self) -> str:
-        """Return the translation stage plugin for the transpiler for IBM backends.
-
-        This automatically configures custom transpilation behavior for IBM backends in Qiskit's
-        transpiler.
-        """
-        return "ibm_dynamic_circuits"
-
     def run(
         self,
         circuits: Union[
@@ -784,7 +776,7 @@ class IBMBackend(Backend):
 
     def get_translation_stage_plugin(self) -> str:
         """Return the default translation stage plugin name for IBM backends."""
-        return "ibm_backend"
+        return "ibm_dynamic_circuits"
 
 
 class IBMRetiredBackend(IBMBackend):

--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -325,14 +325,6 @@ class IBMBackend(Backend):
         self._convert_to_target()
         return self._target
 
-    def get_translation_stage_plugin(self) -> str:
-        """Return the translation stage plugin for the transpiler for IBM backends.
-
-        This automatically configures custom transpilation behavior for IBM backends in Qiskit's
-        transpiler.
-        """
-        return "ibm_dynamic_circuits"
-
     def run(
         self,
         circuits: Union[

--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -325,6 +325,14 @@ class IBMBackend(Backend):
         self._convert_to_target()
         return self._target
 
+    def get_translation_stage_plugin(self) -> str:
+        """Return the translation stage plugin for the transpiler for IBM backends.
+
+        This automatically configures custom transpilation behavior for IBM backends in Qiskit's
+        transpiler.
+        """
+        return "ibm_dynamic_circuits"
+
     def run(
         self,
         circuits: Union[

--- a/qiskit_ibm_provider/transpiler/passes/scheduling/__init__.py
+++ b/qiskit_ibm_provider/transpiler/passes/scheduling/__init__.py
@@ -116,8 +116,8 @@ Scheduling with old format ``c_if`` conditioned gates is not supported.
     qc_c_if.x(0).c_if(0, 1)
     qc_c_if.draw(output="mpl")
 
-The :class:`qiskit_ibm_provider.ibm_backend.IBMBackend` configures a translation plugin
-:class:`qiskit_ibm_provider.transpiler.plugin.IBMTranslationPlugin` to automatically
+The :class:`.IBMBackend` configures a translation plugin
+:class:`.IBMTranslationPlugin` to automatically
 apply transformations and optimizations for IBM hardware backends when invoking
 :class:`qiskit.transpile`. This will automatically convert all old style ``c_if``
 conditioned gates to new-style control-flow.

--- a/qiskit_ibm_provider/transpiler/passes/scheduling/__init__.py
+++ b/qiskit_ibm_provider/transpiler/passes/scheduling/__init__.py
@@ -140,7 +140,7 @@ We may then schedule the transpiled circuit without further modification.
         ]
     )
 
-    qc_if_dd = pm.run(qc_c_if)
+    qc_if_dd = pm.run(qc_c_if_transpiled)
     qc_if_dd.draw(output="mpl")
 
 

--- a/qiskit_ibm_provider/transpiler/passes/scheduling/__init__.py
+++ b/qiskit_ibm_provider/transpiler/passes/scheduling/__init__.py
@@ -119,7 +119,7 @@ Scheduling with old format ``c_if`` conditioned gates is not supported.
 The :class:`.IBMBackend` configures a translation plugin
 :class:`.IBMTranslationPlugin` to automatically
 apply transformations and optimizations for IBM hardware backends when invoking
-:class:`qiskit.transpile`. This will automatically convert all old style ``c_if``
+:func:`~qiskit.compiler.transpile`. This will automatically convert all old style ``c_if``
 conditioned gates to new-style control-flow.
 
 .. jupyter-execute::

--- a/qiskit_ibm_provider/transpiler/passes/scheduling/__init__.py
+++ b/qiskit_ibm_provider/transpiler/passes/scheduling/__init__.py
@@ -125,7 +125,7 @@ conditioned gates to new-style control-flow.
 .. jupyter-execute::
 
     # Temporary workaround for mock backends. For real backends this is not required.
-    backend.get_translation_stage_plugin = lambda: return "ibm_dynamic_circuits"
+    backend.get_translation_stage_plugin = lambda: "ibm_dynamic_circuits"
 
     qc_c_if_transpiled = transpile(qc_c_if, backend)
 

--- a/releasenotes/notes/add-translation-stage-plugin-to-backend-ed753e4323137d1c.yaml
+++ b/releasenotes/notes/add-translation-stage-plugin-to-backend-ed753e4323137d1c.yaml
@@ -4,5 +4,5 @@ upgrade:
     The :class:`qiskit_ibm_provider.ibm_backend.IBMBackend` now returns the
     ``ibm_dynamic_circuits`` translation stage as its plugin
     translation stage. This will automatically add custom
-    transformations when calling the transpiler the are tuned
+    transformations when calling the transpiler that are tuned
     for IBM quantum hardware.

--- a/releasenotes/notes/add-translation-stage-plugin-to-backend-ed753e4323137d1c.yaml
+++ b/releasenotes/notes/add-translation-stage-plugin-to-backend-ed753e4323137d1c.yaml
@@ -1,7 +1,7 @@
 ---
 upgrade:
   - |
-    The :class:`qiskit.ibm_backend.IBMBackend` now returns the
+    The :class:`qiskit_ibm_provider.ibm_backend.IBMBackend` now returns the
     ``ibm_dynamic_circuits`` translation stage as its plugin
     translation stage. This will automatically add custom
     transformations when calling the transpiler the are tuned

--- a/releasenotes/notes/add-translation-stage-plugin-to-backend-ed753e4323137d1c.yaml
+++ b/releasenotes/notes/add-translation-stage-plugin-to-backend-ed753e4323137d1c.yaml
@@ -1,0 +1,8 @@
+---
+upgrade:
+  - |
+    The :class:`qiskit.ibm_backend.IBMBackend` now returns the
+    ``ibm_dynamic_circuits`` translation stage as its plugin
+    translation stage. This will automatically add custom
+    transformations when calling the transpiler the are tuned
+    for IBM quantum hardware.

--- a/test/unit/transpiler/passes/scheduling/test_scheduler.py
+++ b/test/unit/transpiler/passes/scheduling/test_scheduler.py
@@ -794,9 +794,15 @@ class TestASAPSchedulingAndPaddingPass(ControlFlowTestCase):
         self.assertEqual(expected, scheduled)
 
     def test_c_if_plugin_conversion_with_transpile(self):
-        """Verify that old format c_if may be converted and scheduled after transpilation with the plugin."""
+        """Verify that old format c_if may be converted and scheduled
+        after transpilation with the plugin."""
         # Patch the test backend with the plugin
-        with patch.object(FakeJakarta, 'get_translation_stage_plugin', return_value="ibm_dynamic_circuits", create=True):
+        with patch.object(
+            FakeJakarta,
+            "get_translation_stage_plugin",
+            return_value="ibm_dynamic_circuits",
+            create=True,
+        ):
             backend = FakeJakarta()
             # Temporary workaround for mock backends. For real backends this is not required.
             backend.configuration().basis_gates.append("if_else")
@@ -1804,9 +1810,15 @@ class TestALAPSchedulingAndPaddingPass(ControlFlowTestCase):
         self.assertEqual(expected, scheduled)
 
     def test_c_if_plugin_conversion_with_transpile(self):
-        """Verify that old format c_if may be converted and scheduled after transpilation with the plugin."""
+        """Verify that old format c_if may be converted and scheduled after
+        transpilation with the plugin."""
         # Patch the test backend with the plugin
-        with patch.object(FakeJakarta, 'get_translation_stage_plugin', return_value="ibm_dynamic_circuits", create=True):
+        with patch.object(
+            FakeJakarta,
+            "get_translation_stage_plugin",
+            return_value="ibm_dynamic_circuits",
+            create=True,
+        ):
             backend = FakeJakarta()
             # Temporary workaround for mock backends. For real backends this is not required.
             backend.configuration().basis_gates.append("if_else")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR builds on #480 and #420 to enable translation plugins for provider backends by default. This is a powerful feature that will solve usability issues with new-style control-flow.

As this is based on #420 for reviewing purposes look at - https://github.com/Qiskit/qiskit-ibm-provider/pull/483/files/4b446b04e25912f0de6a45a49e37532ed896a4bc..25f35228c0aad6ce3000fca7fc4aca2261c27a75

### Details and comments
Currently the plugin is named `ibm_dynamic_circuits` but applies transformations that are generally good for IBM backends. The `IBMBackend` currently does not differentiate between dynamic/non-dynamic circuit backends but this might be desirable in the long run. Perhaps, in the near term we could rename `ibm_dynamic_circuits` to `ibm` or something along these lines (or keep both and have them be identical).

