### PR TITLE
Remove `input_allowed` parameter when filtering backends 

### DIFF
--- a/qiskit_ibm_provider/ibm_backend_service.py
+++ b/qiskit_ibm_provider/ibm_backend_service.py
@@ -108,7 +108,6 @@ class IBMBackendService:
         name: Optional[str] = None,
         filters: Optional[Callable[[List[IBMBackend]], bool]] = None,
         min_num_qubits: Optional[int] = None,
-        input_allowed: Optional[Union[str, List[str]]] = None,
         instance: Optional[str] = None,
         dynamic_circuits: Optional[bool] = None,
         **kwargs: Any,
@@ -123,11 +122,6 @@ class IBMBackendService:
                     IBMProvider.backends(
                         filters=lambda b: b.configuration().quantum_volume > 16)
             min_num_qubits: Minimum number of qubits the backend has to have.
-            input_allowed: Filter by the types of input the backend supports.
-                Valid input types are ``job`` (circuit job) and ``runtime`` (Qiskit Runtime).
-                For example, ``inputs_allowed='runtime'`` will return all backends
-                that support Qiskit Runtime. If a list is given, the backend must
-                support all types specified in the list.
             instance: The provider in the hub/group/project format.
             dynamic_circuits: Filter by whether the backend supports dynamic circuits.
             **kwargs: Simple filters that specify a ``True``/``False`` criteria in the
@@ -158,16 +152,6 @@ class IBMBackendService:
         if min_num_qubits:
             backends = list(
                 filter(lambda b: b.configuration().n_qubits >= min_num_qubits, backends)
-            )
-        if input_allowed:
-            if not isinstance(input_allowed, list):
-                input_allowed = [input_allowed]
-            backends = list(
-                filter(
-                    lambda b: set(input_allowed)
-                    <= set(b.configuration().input_allowed),
-                    backends,
-                )
             )
         if dynamic_circuits is not None:
             backends = list(

--- a/qiskit_ibm_provider/ibm_provider.py
+++ b/qiskit_ibm_provider/ibm_provider.py
@@ -521,7 +521,6 @@ class IBMProvider(Provider):
         name: Optional[str] = None,
         filters: Optional[Callable[[List[IBMBackend]], bool]] = None,
         min_num_qubits: Optional[int] = None,
-        input_allowed: Optional[Union[str, List[str]]] = None,
         instance: Optional[str] = None,
         **kwargs: Any,
     ) -> List[IBMBackend]:
@@ -534,11 +533,6 @@ class IBMProvider(Provider):
 
                     IBMProvider.backends(filters=lambda b: b.configuration().quantum_volume > 16)
             min_num_qubits: Minimum number of qubits the backend has to have.
-            input_allowed: Filter by the types of input the backend supports.
-                Valid input types are ``job`` (circuit job) and ``runtime`` (Qiskit Runtime).
-                For example, ``inputs_allowed='runtime'`` will return all backends
-                that support Qiskit Runtime. If a list is given, the backend must
-                support all types specified in the list.
             instance: The provider in the hub/group/project format.
             **kwargs: Simple filters that specify a ``True``/``False`` criteria in the
                 backend configuration, backends status, or provider credentials.
@@ -554,7 +548,6 @@ class IBMProvider(Provider):
             name=name,
             filters=filters,
             min_num_qubits=min_num_qubits,
-            input_allowed=input_allowed,
             instance=instance,
             **kwargs,
         )

--- a/releasenotes/notes/remove-input-allowed-681fa25bf558e3f8.yaml
+++ b/releasenotes/notes/remove-input-allowed-681fa25bf558e3f8.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Filtering backends with the parameter ``input_allowed`` in 
+    :meth:`~qiskit_ibm_provider.IBMBackendService.backends`
+    has been removed because it is no longer in use and not supported 
+    by the runtime api.

--- a/test/integration/test_filter_backends.py
+++ b/test/integration/test_filter_backends.py
@@ -123,23 +123,6 @@ class TestBackendFilters(IBMTestCase):
                 self.assertGreaterEqual(backend.configuration().n_qubits, 5)
                 self.assertTrue(backend.configuration().quantum_volume, 10)
 
-    def test_filter_input_allowed(self):
-        """Test filtering by input allowed"""
-        subtests = ("job", ["job"], ["job", "runtime"])
-
-        for input_type in subtests:
-            with self.subTest(input_type=input_type):
-                filtered = self.dependencies.provider.backends(
-                    input_allowed=input_type, instance=self.dependencies.instance
-                )
-                self.assertTrue(filtered)
-                if not isinstance(input_type, list):
-                    input_type = [input_type]
-                for backend in filtered[:5]:
-                    self.assertTrue(
-                        set(input_type) <= set(backend.configuration().input_allowed)
-                    )
-
     def test_filter_dynamic_circuits(self):
         """Test filtering by dynamic ciruits."""
         filtered = self.dependencies.provider.backends(dynamic_circuits=True)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`input_allowed` is no longer in use and not supported by the runtime api 

### Details and comments


