### PR TITLE
Update code block + hyperlink to hyperlink only

### DIFF
--- a/docs/tutorials/1_the_ibm_quantum_account.ipynb
+++ b/docs/tutorials/1_the_ibm_quantum_account.ipynb
@@ -368,7 +368,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[`IBMBackend`](https://qiskit.org/documentation/partners/qiskit_ibm_provider/stubs/qiskit_ibm_provider.IBMBackend.html#qiskit_ibm_provider.IBMBackend) also accepts additional parameters to the `run()` method:\n",
+    "[IBMBackend](https://qiskit.org/documentation/partners/qiskit_ibm_provider/stubs/qiskit_ibm_provider.IBMBackend.html#qiskit_ibm_provider.IBMBackend) also accepts additional parameters to the `run()` method:\n",
     "\n",
     "- `job_tags`: Tags to be assigned to the job.\n",
     "\n",
@@ -376,7 +376,7 @@
     "\n",
     "- `defaults()`: Gives a data structure of typical default parameters, if applicable.\n",
     "\n",
-    "Refer to the [`IBMBackend`](https://qiskit.org/documentation/partners/qiskit_ibm_provider/stubs/qiskit_ibm_provider.IBMBackend.html#qiskit_ibm_provider.IBMBackend) documentation for a complete list of methods."
+    "Refer to the [IBMBackend](https://qiskit.org/documentation/partners/qiskit_ibm_provider/stubs/qiskit_ibm_provider.IBMBackend.html#qiskit_ibm_provider.IBMBackend) documentation for a complete list of methods."
    ]
   },
   {


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The rst cannot render code block + hyperlink, it's only either/or.

This PR fixes the docs -- https://qiskit.org/documentation/partners/qiskit_ibm_provider/tutorials/1_the_ibm_quantum_account.html#Backends

<img width="668" alt="image" src="https://user-images.githubusercontent.com/11485594/218154881-47800bd3-4d6c-4109-a336-849af3a32250.png">


### Details and comments


