### PR TITLE
[WIP] Enable retrieval of historical data for 'target' and 'defaults'

### DIFF
--- a/qiskit_ibm_provider/api/clients/runtime.py
+++ b/qiskit_ibm_provider/api/clients/runtime.py
@@ -67,7 +67,7 @@ class RuntimeClient(BaseClient):
         """
         return self._api.backend(backend).properties(datetime=datetime)
 
-    def backend_pulse_defaults(self, backend: str) -> Dict:
+    def backend_pulse_defaults(self, backend: str, datetime: Optional[python_datetime] = None) -> Dict:
         """Return the pulse defaults of the backend.
 
         Args:
@@ -76,7 +76,7 @@ class RuntimeClient(BaseClient):
         Returns:
             Backend pulse defaults.
         """
-        return self._api.backend(backend).pulse_defaults()
+        return self._api.backend(backend).pulse_defaults(datetime=datetime)
 
     def backend_status(self, backend: str) -> Dict[str, Any]:
         """Return the status of the backend.

--- a/qiskit_ibm_provider/api/rest/backend.py
+++ b/qiskit_ibm_provider/api/rest/backend.py
@@ -78,14 +78,19 @@ class Backend(RestAdapterBase):
 
         return response
 
-    def pulse_defaults(self) -> Dict[str, Any]:
+    def pulse_defaults(self, datetime: Optional[datetime] = None) -> Dict[str, Any]:
         """Return backend pulse defaults.
 
         Returns:
             JSON response of pulse defaults.
         """
         url = self.get_url("pulse_defaults")
-        return self.session.get(url).json()
+        params = {}
+        if datetime:
+            params["updated_before"] = datetime.isoformat()
+
+        return self.session.get(url, params=params).json()
+
 
     def status(self) -> Dict[str, Any]:
         """Return backend status.

--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -318,10 +318,21 @@ class IBMBackend(Backend):
         """
         return self._configuration.meas_map
 
-    def target(self, datetime: Optional[python_datetime] = None) -> Target:
+    @property
+    def target(self) -> Target:
         """A :class:`qiskit.transpiler.Target` object for the backend.
         Returns:
             Target
+        """
+        self._get_properties()
+        self._get_defaults()
+        self._convert_to_target()
+        return self._target
+
+    def target_history(self, datetime: Optional[python_datetime] = None) -> Target:
+        """A :class:`qiskit.transpiler.Target` object for the backend.
+        Returns:
+            Target with properties found on `datetime`
         """
         self._get_properties(datetime=datetime)
         self._get_defaults()

--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -257,10 +257,14 @@ class IBMBackend(Backend):
                 )
             )
 
-    def _get_properties(self) -> None:
+    def _get_properties(self, datetime: Optional[python_datetime] = None) -> None:
         """Gets backend properties and decodes it"""
         if not self._properties:
-            api_properties = self.provider._runtime_client.backend_properties(self.name)
+            if datetime:
+                datetime = local_to_utc(datetime)
+            api_properties = self.provider._runtime_client.backend_properties(
+                self.name, datetime=datetime
+            )
             if api_properties:
                 backend_properties = properties_from_server_data(api_properties)
                 self._properties = backend_properties
@@ -314,13 +318,12 @@ class IBMBackend(Backend):
         """
         return self._configuration.meas_map
 
-    @property
-    def target(self) -> Target:
+    def target(self, datetime: Optional[python_datetime] = None) -> Target:
         """A :class:`qiskit.transpiler.Target` object for the backend.
         Returns:
             Target
         """
-        self._get_properties()
+        self._get_properties(datetime=datetime)
         self._get_defaults()
         self._convert_to_target()
         return self._target
@@ -583,6 +586,7 @@ class IBMBackend(Backend):
             api_properties = self.provider._runtime_client.backend_properties(
                 self.name, datetime=datetime
             )
+
             if not api_properties:
                 return None
             backend_properties = properties_from_server_data(api_properties)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Allow the user to retrieve historical data for the `target` and for `pulse_defaults` of the `backend`.


### Details and comments
This is similar to the support that already exists for `backend.properties`. For `target`, we defined a new method - `target_history`, since `target` is defined as a property.

