### PR TITLE
Look up whether "date" is included in the `result_dict`, not string `result`

### DIFF
--- a/qiskit_ibm_provider/utils/json_decoder.py
+++ b/qiskit_ibm_provider/utils/json_decoder.py
@@ -106,7 +106,7 @@ def decode_result(result: str, result_decoder: Any) -> Dict:
         result_decoder: A decoder class for loading the json
     """
     result_dict = json.loads(result, cls=result_decoder)
-    if "date" in result:
+    if "date" in result_dict:
         if isinstance(result_dict["date"], str):
             result_dict["date"] = dateutil.parser.isoparse(result_dict["date"])
         result_dict["date"] = utc_to_local(result_dict["date"])


### PR DESCRIPTION
### Summary

When decoding a circuit job result, the date contained in the result json can either be an object which is decoded by the `RuntimeDecoder` or a string. In case it's a string, it needs to be handled correctly and parsed as an object in `json_decoder.py:decode_result`. 

### Details and comments

At the moment, the `decode_result` code is looking at `result` which is the result as a string, but it should look at the json result instead.
