### PR TITLE
Remove additional decomposition of ``BlueprintCircuit`` in JSON encode

### DIFF
--- a/qiskit_ibm_provider/utils/json.py
+++ b/qiskit_ibm_provider/utils/json.py
@@ -45,7 +45,6 @@ from qiskit.circuit import (
     QuantumCircuit,
     QuantumRegister,
 )
-from qiskit.circuit.library import BlueprintCircuit
 from qiskit.result import Result
 from qiskit.version import __version__ as _terra_version_string
 

--- a/qiskit_ibm_provider/utils/json.py
+++ b/qiskit_ibm_provider/utils/json.py
@@ -211,9 +211,6 @@ class RuntimeEncoder(json.JSONEncoder):
         if hasattr(obj, "to_json"):
             return {"__type__": "to_json", "__value__": obj.to_json()}
         if isinstance(obj, QuantumCircuit):
-            # TODO Remove the decompose when terra 6713 is released.
-            if isinstance(obj, BlueprintCircuit):
-                obj = obj.decompose()
             value = _serialize_and_encode(
                 data=obj,
                 serializer=lambda buff, data: dump(data, buff),  # type: ignore[no-untyped-call]

--- a/releasenotes/notes/remove-blueprint-decompose-d1545b3bd6d7e3a2.yaml
+++ b/releasenotes/notes/remove-blueprint-decompose-d1545b3bd6d7e3a2.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Removed additional decomposition of ``BlueprintCircuit``\s in the JSON encoder. This was
+    introduced as a bugfix, but has since been fixed. Still doing the decomposition led to
+    possible problems if the decomposed circuit was not in the correct basis set of the backend
+    anymore.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The JSON encoder currently hardcodes a decomposition of any `BlueprintCircuit` it sees,
which was a workaround of a bug that has since (in July 21 actually) been fixed: Qiskit/qiskit-terra#7613. Keeping this decomposition leads to potential errors, for example if a user compiles a `BlueprintCircuit` for a device, the circuit will be decomposed again and doesn't match the basis set anymore.

### Details and comments

Here's the comment that tells us we should remove the decomposition (but we forgot to do so.... 😄): https://github.com/Qiskit/qiskit-ibm-runtime/blob/013d7dd46ef21f7c63dc73023d47aed78cdd0c15/qiskit_ibm_runtime/utils/json.py#L222

