### PR TITLE
Fix JSONDecodeError error when job results contained substring "url"

### DIFF
--- a/qiskit_ibm_provider/job/ibm_circuit_job.py
+++ b/qiskit_ibm_provider/job/ibm_circuit_job.py
@@ -672,14 +672,15 @@ class IBMCircuitJob(IBMJob):
         Args:
             response: Response to check for url keyword, if available, download result from given URL
         """
-        if "url" in response:
+        try:
             result_url_json = json.loads(response)
             if "url" in result_url_json:
                 url = result_url_json["url"]
                 result_response = requests.get(url)
-                response = result_response.content
-
-        return response
+                return result_response.content
+        except json.JSONDecodeError:
+            return response
+       
 
     def _retrieve_result(self, refresh: bool = False) -> None:
         """Retrieve the job result response.

--- a/qiskit_ibm_provider/job/ibm_circuit_job.py
+++ b/qiskit_ibm_provider/job/ibm_circuit_job.py
@@ -678,7 +678,7 @@ class IBMCircuitJob(IBMJob):
                 url = result_url_json["url"]
                 result_response = requests.get(url)
                 return result_response.content
-            return response  
+            return response
         except json.JSONDecodeError:
             return response
 

--- a/qiskit_ibm_provider/job/ibm_circuit_job.py
+++ b/qiskit_ibm_provider/job/ibm_circuit_job.py
@@ -678,7 +678,7 @@ class IBMCircuitJob(IBMJob):
                 url = result_url_json["url"]
                 result_response = requests.get(url)
                 return result_response.content
-            return response  # add this line
+            return response  
         except json.JSONDecodeError:
             return response
 

--- a/qiskit_ibm_provider/job/ibm_circuit_job.py
+++ b/qiskit_ibm_provider/job/ibm_circuit_job.py
@@ -678,9 +678,9 @@ class IBMCircuitJob(IBMJob):
                 url = result_url_json["url"]
                 result_response = requests.get(url)
                 return result_response.content
+            return response  # add this line
         except json.JSONDecodeError:
             return response
-       
 
     def _retrieve_result(self, refresh: bool = False) -> None:
         """Retrieve the job result response.


### PR DESCRIPTION
### Summary
Solves https://github.com/Qiskit/qiskit-ibm-provider/issues/554.


### Details and comments
https://github.com/Qiskit/qiskit-ibm-provider/pull/551 introduced a regression for jobs (e.g. failure logs) included the string "url".

