### PR TITLE
Only run custom translation stage when needed

### DIFF
--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -796,7 +796,9 @@ class IBMBackend(Backend):
 
     def get_translation_stage_plugin(self) -> str:
         """Return the default translation stage plugin name for IBM backends."""
-        return "ibm_dynamic_circuits"
+        if "id" not in self.target:
+            return "ibm_dynamic_circuits"
+        return None
 
 
 class IBMRetiredBackend(IBMBackend):

--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -796,9 +796,7 @@ class IBMBackend(Backend):
 
     def get_translation_stage_plugin(self) -> str:
         """Return the default translation stage plugin name for IBM backends."""
-        if "id" not in self.target:
-            return "ibm_dynamic_circuits"
-        return None
+        return "ibm_dynamic_circuits"
 
 
 class IBMRetiredBackend(IBMBackend):

--- a/qiskit_ibm_provider/transpiler/plugin.py
+++ b/qiskit_ibm_provider/transpiler/plugin.py
@@ -79,7 +79,12 @@ class IBMDynamicTranslationPlugin(PassManagerStagePlugin):
 
         instruction_durations = pass_manager_config.instruction_durations
         plugin_passes = []
-        if instruction_durations:
+        if pass_manager_config.target is not None:
+            id_supported = "id" in pass_manager_config.target
+        else:
+            id_supported = "id" in pass_manager_config.basis_gates
+
+        if instruction_durations and not id_supported:
             plugin_passes.append(ConvertIdToDelay(instruction_durations))
 
         # Only inject control-flow conversion pass at level 0 and level 1. As of


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit updates the hook point method for the default translation stage in the IBMBackend class to only return the custom translation stage when id is not a basis gate. The custom translation plugin is basically the normal qiskit default method, 'translator' with an extra pass to convert IGate into Delay with a single qubit gate duration. This is custom behavior for IBM backends and doing this as a custom translation stage plugin makes sense. However, most IBM backends currently still support id as an operation and will translate that to the appropriate delay automatically. We should not do this custom translation if the backend still advertises support for id, especially given the issues under discussion around using delay (see: Qiskit/qiskit-terra#9888).

### Details and comments