### PR TITLE
Raise error if backend not in instance

### DIFF
--- a/qiskit_ibm_provider/ibm_backend_service.py
+++ b/qiskit_ibm_provider/ibm_backend_service.py
@@ -157,9 +157,12 @@ class IBMBackendService:
         Raises:
             IBMBackendValueError: If only one or two parameters from `hub`, `group`,
                 `project` are specified.
+            QiskitBackendNotFoundError: If the backend is not found in any instance.
         """
         backends: List[IBMBackend] = []
         if name:
+            if name not in self._backends:
+                raise QiskitBackendNotFoundError("No backend matches the criteria")
             if not self._backends[name] or instance != self._backends[name]._instance:
                 self._set_backend_config(name)
                 self._backends[name] = self._create_backend_obj(

--- a/qiskit_ibm_provider/ibm_backend_service.py
+++ b/qiskit_ibm_provider/ibm_backend_service.py
@@ -682,12 +682,23 @@ class IBMBackendService:
             instance: the current h/g/p.
         Returns:
             A backend object.
+        Raises:
+            QiskitBackendNotFoundError: if the backend is not in the hgp passed in.
         """
         if not instance:
             for hgp in hgps:
                 if config.backend_name in hgp.backends:
                     instance = to_instance_format(hgp._hub, hgp._group, hgp._project)
                     break
+
+        elif (
+            config.backend_name
+            not in self._provider._get_hgp(instance=instance).backends
+        ):
+            raise QiskitBackendNotFoundError(
+                f"Backend {config.backend_name} is not in "
+                f"{instance}: please try a different hub/group/project."
+            )
 
         return ibm_backend.IBMBackend(
             instance=instance,

--- a/test/integration/test_backend.py
+++ b/test/integration/test_backend.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 
 from qiskit import QuantumCircuit, transpile
 from qiskit.providers.models import QasmBackendConfiguration
+from qiskit.providers.exceptions import QiskitBackendNotFoundError
 from qiskit.test.reference_circuits import ReferenceCircuits
 
 from qiskit_ibm_provider import IBMBackend, IBMProvider
@@ -166,3 +167,19 @@ class TestIBMBackend(IBMTestCase):
         op_counts = tqc.count_ops()
         self.assertNotIn("id", op_counts)
         self.assertIn("delay", op_counts)
+
+    def test_backend_wrong_instance(self):
+        """Test that an error is raised when retrieving a backend not in the instance."""
+        backends = self.dependencies.provider.backends()
+        hgps = self.dependencies.provider._hgps.values()
+        if len(hgps) >= 2:
+            for hgp in hgps:
+                backend_names = list(hgp._backends)
+                for backend in backends:
+                    if backend.name not in backend_names:
+                        with self.assertRaises(QiskitBackendNotFoundError):
+                            self.dependencies.provider.get_backend(
+                                backend.name,
+                                instance=f"{hgp._hub}/{hgp._group}/{hgp._project}",
+                            )
+                        return

--- a/test/integration/test_backend.py
+++ b/test/integration/test_backend.py
@@ -183,3 +183,8 @@ class TestIBMBackend(IBMTestCase):
                                 instance=f"{hgp._hub}/{hgp._group}/{hgp._project}",
                             )
                         return
+
+    def test_retrieve_backend_not_exist(self):
+        """Test that an error is raised when retrieving a backend that does not exist."""
+        with self.assertRaises(QiskitBackendNotFoundError):
+            self.dependencies.provider.get_backend("nonexistent_backend")


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

after the recent lazy loading changes, an error is not raised if both a backend name and instance are provided and the backend is not in the given instance, leading to an unexpected job failure 

```python
backend = provider.get_backend('ibm_seattle', instance='ibm-q/open/main')  
# should raise an error bc seattle is not in this h/g/p
```

### Details and comments


