### PR TITLE
Fix `test_retrieve_legacy_jobs` test

### DIFF
--- a/test/integration/test_ibm_job.py
+++ b/test/integration/test_ibm_job.py
@@ -153,7 +153,6 @@ class TestIBMJob(IBMTestCase):
             backend_name=backend_name,
             limit=5,
             skip=0,
-            legacy=True,
         )
         job_ids = [job.job_id() for job in job_list]
         self.assertTrue(job1.job_id() in job_ids)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Since all jobs are being rerouted to use the runtime api, the legacy flag will no longer work for any of these new jobs 

### Details and comments


