### PR TITLE
Fix bug where pending jobs were not being returned in backend status 

### DIFF
--- a/qiskit_ibm_provider/api/rest/backend.py
+++ b/qiskit_ibm_provider/api/rest/backend.py
@@ -105,8 +105,8 @@ class Backend(RestAdapterBase):
         }
 
         # 'pending_jobs' is required, and should be >= 0.
-        if "lengthQueue" in response:
-            ret["pending_jobs"] = max(response["lengthQueue"], 0)
+        if "length_queue" in response:
+            ret["pending_jobs"] = max(response["length_queue"], 0)
         else:
             ret["pending_jobs"] = 0
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Pending jobs are returned from the api as `length_queue` not `LengthQueue`
 
<img width="196" alt="Screenshot 2023-04-13 at 12 31 54 PM" src="https://user-images.githubusercontent.com/20911417/231825550-9bf493b4-04b7-4844-9951-c0d5deb3a2fe.png">


### Details and comments

fixes #580 
