### PR TITLE
Add warning if backend doesn't support backend circuits

### DIFF
--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -427,11 +427,10 @@ class IBMBackend(Backend):
 
         validate_job_tags(job_tags, IBMBackendValueError)
 
-        if dynamic:
-            if "qasm3" not in getattr(self.configuration(), "supported_features", []):
-                warnings.warn(
-                    f"The backend {self.name} does not support dynamic circuits."
-                )
+        if dynamic and "qasm3" not in getattr(
+            self.configuration(), "supported_features", []
+        ):
+            warnings.warn(f"The backend {self.name} does not support dynamic circuits.")
 
         status = self.status()
         if status.operational is True and status.status_msg != "active":

--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -427,6 +427,12 @@ class IBMBackend(Backend):
 
         validate_job_tags(job_tags, IBMBackendValueError)
 
+        if dynamic:
+            if "qasm3" not in getattr(self.configuration(), "supported_features", []):
+                warnings.warn(
+                    f"The backend {self.name} does not support dynamic circuits."
+                )
+
         status = self.status()
         if status.operational is True and status.status_msg != "active":
             warnings.warn(f"The backend {self.name} is currently paused.")

--- a/releasenotes/notes/dynamic-backend-warning-560fd896a1dc6ffd.yaml
+++ b/releasenotes/notes/dynamic-backend-warning-560fd896a1dc6ffd.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    If the ``dynamic`` parameter is set to ``True`` in :meth:`~qiskit_ibm_provider.IBMBackend.run` 
+    and the backend being used does not support dymamic circuits, a warning will be raised. 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds a warning if the `dynamic=True` flag is used and the backend selected does not support backend circuits 

fixes #594 

### Details and comments


