### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, '3.10' ]
+        python-version: [ 3.8, 3.9, '3.10' ]
         os: [ "macOS-latest", "ubuntu-latest", "windows-latest" ]
     env:
       LOG_LEVEL: DEBUG

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: [3.9]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ omit = qiskit_ibm_provider/jupyter/*,qiskit_ibm_provider/visualization/*
 
 [mypy]
 exclude = test/integration/test_jupyter.py
-python_version = 3.7
+python_version = 3.8
 namespace_packages = True
 ignore_missing_imports = True
 warn_redundant_casts = True

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,6 @@ setuptools.setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -73,7 +72,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=["test*"]),
     install_requires=REQUIREMENTS,
     include_package_data=True,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     zip_safe=False,
     extras_require={
         "visualization": [

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-minversion = 2.1
-envlist = py37, py38, py39, py310, lint, docs
+minversion = 3.15
+envlist = py38, py39, py310, lint, docs
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Python 3.7 is End of Life on June 27: https://endoflife.date/python.

The broader Python ecosystem is dropping support, such as Sphinx 6 no longer working with Python 3.7. That means that, currently, we may get a different docs build depending on whether we run with Python 3.7 or later.

Pip is smart enough to know how to handle interpreter versions. If a user is still on Python 3.7, then `pip install qiskit-ibm-provider` will simply install an older version of the package that still works with 3.7.

### Details and comments

See https://github.com/Qiskit/qiskit-experiments/pull/1112 for a similar PR in qiskit-experiments.