### PR TITLE
Turn off CI for forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   code-quality:
+    if: github.repository_owner == 'Qiskit'
     name: Run code quality checks
     runs-on: ubuntu-latest
     steps:
@@ -41,6 +42,7 @@ jobs:
       - name: Run mypy
         run: make mypy
   documentation:
+    if: github.repository_owner == 'Qiskit'
     name: Build documentation
     runs-on: ubuntu-latest
     steps:
@@ -65,6 +67,7 @@ jobs:
           name: html_docs
           path: docs/_build/html
   unit-tests:
+    if: github.repository_owner == 'Qiskit'
     # only kick-off test cases when basic code quality checks succeed
     needs: [ "code-quality" , "documentation" ]
     name: Run unit tests - python${{ matrix.python-version }}-${{ matrix.os }}
@@ -100,7 +103,7 @@ jobs:
           parallel: true
           path-to-lcov: coverage.lcov
   integration-tests-1:
-    if: ${{ github.event_name == 'push' }}
+    if: github.event_name == 'push' && github.repository_owner == 'Qiskit'
     # only kick-off resource intensive integration tests if unit tests and all basic checks succeeded
     needs: [ "unit-tests" ]
     name: Run integration tests 1 - ${{ matrix.environment }}
@@ -136,7 +139,7 @@ jobs:
       - name: Run integration tests 1
         run: make integration-test-1
   integration-tests-2:
-    if: ${{ github.event_name == 'push' }}
+    if: github.event_name == 'push' && github.repository_owner == 'Qiskit'
     # only kick-off resource intensive integration tests if unit tests and all basic checks succeeded
     needs: [ "unit-tests" ]
     name: Run integration tests 2 - ${{ matrix.environment }}
@@ -172,7 +175,7 @@ jobs:
       - name: Run integration tests 2
         run: make integration-test-2
   integration-tests-3:
-    if: ${{ github.event_name == 'push' }}
+    if: github.event_name == 'push' && github.repository_owner == 'Qiskit'
     # only kick-off resource intensive integration tests if unit tests and all basic checks succeeded
     needs: [ "unit-tests" ]
     name: Run integration tests 3 - ${{ matrix.environment }}
@@ -208,6 +211,7 @@ jobs:
       - name: Run integration tests 3
         run: make integration-test-3
   tests-finished:
+    if: github.repository_owner == 'Qiskit'
     name: Submit code coverage metrics
     needs: [ unit-tests ]
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -18,6 +18,7 @@ on:
   workflow_dispatch:
 jobs:
   e2e-tests:
+    if: github.repository_owner == 'Qiskit'
     name: Run e2e tests - ${{ matrix.environment }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,6 +18,7 @@ on:
   workflow_dispatch:
 jobs:
   integration-tests-1:
+    if: github.repository_owner == 'Qiskit'
     name: Run integration tests 1 - ${{ matrix.environment }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -51,6 +52,7 @@ jobs:
       - name: Run integration tests 1
         run: make integration-test-1
   integration-tests-2:
+    if: github.repository_owner == 'Qiskit'
     name: Run integration tests 2 - ${{ matrix.environment }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -84,6 +86,7 @@ jobs:
       - name: Run integration tests 2
         run: make integration-test-2
   integration-tests-3:
+    if: github.repository_owner == 'Qiskit'
     name: Run integration tests 3 - ${{ matrix.environment }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/unit-tests-terra-main.yml
+++ b/.github/workflows/unit-tests-terra-main.yml
@@ -17,6 +17,7 @@ on:
   workflow_dispatch:
 jobs:
   unit-tests-latest-qiskit-terra:
+    if: github.repository_owner == 'Qiskit'
     name: Run unit tests with latest code of qiskit-terra
     runs-on: "ubuntu-latest"
     env:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Most people agree that GitHub made a mistake by having forks run CI both on the fork and in the upstream repository. It wastes computing resources (which has a real environmental cost!). In this repo in particular, the integration tests fail for forks because config is not set up properly.

### Details and comments

If people really want to run CI in their fork, they can always modify their fork's config to revert this change.
