### PR TITLE
Update last failing  integration tests

### DIFF
--- a/test/integration/test_backend.py
+++ b/test/integration/test_backend.py
@@ -160,7 +160,7 @@ class TestIBMBackend(IBMTestCase):
                 mutated_circuit = self.backend._deprecate_id_instruction(
                     circuit_with_id
                 )
-            self.assertEqual(mutated_circuit.count_ops(), {"delay": 3})
+            self.assertEqual(mutated_circuit[0].count_ops(), {"delay": 3})
             self.assertEqual(circuit_with_id.count_ops(), {"id": 3})
 
     @skip("This is a Terra issue and test. Not related to Provider.")

--- a/test/integration/test_ibm_provider.py
+++ b/test/integration/test_ibm_provider.py
@@ -298,19 +298,6 @@ class TestIBMProviderServices(IBMTestCase):
                 else:
                     self.assertEqual(properties, None)
 
-    def test_provider_backend(self):
-        """Test provider backend has correct attributes."""
-        backend_attributes = {
-            back
-            for back in dir(self.dependencies.provider.backend)
-            if isinstance(getattr(self.dependencies.provider.backend, back), IBMBackend)
-        }
-        backends = {
-            back.name.lower()
-            for back in self.dependencies.provider.backend._backends.values()
-        }
-        self.assertEqual(backend_attributes, backends)
-
     def test_provider_has_backend_service(self):
         """Test provider has backend service."""
         self.assertIsInstance(self.dependencies.provider.backend, IBMBackendService)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

After the lazy loading updates, `test_provider_backend` is no longer a relevant test 

### Details and comments


