### PR TITLE
Update faulty qubit filtering

### DIFF
--- a/qiskit_ibm_provider/ibm_qubit_properties.py
+++ b/qiskit_ibm_provider/ibm_qubit_properties.py
@@ -23,6 +23,7 @@ class IBMQubitProperties(QubitProperties):
         "t2",
         "frequency",
         "anharmonicity",
+        "operational",
     )
 
     def __init__(  # type: ignore[no-untyped-def]
@@ -31,6 +32,7 @@ class IBMQubitProperties(QubitProperties):
         t2=None,
         frequency=None,
         anharmonicity=None,
+        operational=True,
     ):
         """Create a new ``IBMQubitProperties`` object
 
@@ -39,9 +41,11 @@ class IBMQubitProperties(QubitProperties):
             t2: The T2 time for a qubit in secs
             frequency: The frequency of a qubit in Hz
             anharmonicity: The anharmonicity of a qubit in Hz
+            operational: A boolean value representing if this qubit is operational.
         """
         super().__init__(t1=t1, t2=t2, frequency=frequency)
         self.anharmonicity = anharmonicity
+        self.operational = operational
 
     def __repr__(self):  # type: ignore[no-untyped-def]
         return (

--- a/qiskit_ibm_provider/utils/json_decoder.py
+++ b/qiskit_ibm_provider/utils/json_decoder.py
@@ -103,9 +103,6 @@ def target_from_server_data(
     Returns:
         A ``Target`` instance.
     """
-    if properties:
-        backend_properties = properties_from_server_data(properties)
-        faulty_qubits = set(backend_properties.faulty_qubits())
     required = ["measure", "delay"]
 
     # Load Qiskit object representation
@@ -131,6 +128,8 @@ def target_from_server_data(
     inst_name_map = {}  # type: Dict[str, Instruction]
     prop_name_map = {}  # type: Dict[str, Dict[Tuple[int, ...], InstructionProperties]]
     all_instructions = set.union(supported_instructions, basis_gates, set(required))
+    faulty_qubits = set()
+    faulty_ops = set()
 
     # Create name to Qiskit instruction object repr mapping
     for name in all_instructions:
@@ -159,35 +158,25 @@ def target_from_server_data(
             all_instructions.remove(name)
             continue
 
-    # Create placeholder for the instruction properties
+    # Create empty inst properties from gate configs
     for name, spec in gate_configs.items():
         if hasattr(spec, "coupling_map"):
             coupling_map = spec.coupling_map
             prop_name_map[name] = dict.fromkeys(map(tuple, coupling_map))
         else:
             prop_name_map[name] = None
-    if "delay" not in prop_name_map:
-        # Case for real IBM backend. They don't have delay in gate configuration.
-        prop_name_map["delay"] = {
-            (q,): None
-            for q in range(configuration.num_qubits)
-            if q not in faulty_qubits
-        }
 
     # Populate instruction properties
     if properties:
-        in_data["qubit_properties"] = list(
-            map(_decode_qubit_property, properties["qubits"])
+        qubit_properties = list(map(_decode_qubit_property, properties["qubits"]))
+        in_data["qubit_properties"] = qubit_properties
+        faulty_qubits = set(
+            q for q, prop in enumerate(qubit_properties) if not prop.operational
         )
+
         for gate_spec in map(GateSchema.from_dict, properties["gates"]):
             name = gate_spec.gate
             qubits = tuple(gate_spec.qubits)
-            if any(
-                not backend_properties.is_qubit_operational(qubit) for qubit in qubits
-            ):
-                continue
-            if not backend_properties.is_gate_operational(name, gate_spec.qubits):
-                continue
             if name not in all_instructions:
                 logger.info(
                     "Gate property for instruction %s on qubits %s is found "
@@ -198,7 +187,14 @@ def target_from_server_data(
                     qubits,
                 )
                 continue
-            inst_prop = _decode_instruction_property(gate_spec)
+            inst_prop, operational = _decode_instruction_property(gate_spec)
+            if set.intersection(faulty_qubits, qubits) or not operational:
+                faulty_ops.add((name, qubits))
+                try:
+                    del prop_name_map[name][qubits]
+                except KeyError:
+                    pass
+                continue
             if prop_name_map[name] is None:
                 prop_name_map[name] = {}
             prop_name_map[name][qubits] = inst_prop
@@ -206,10 +202,18 @@ def target_from_server_data(
         measure_props = list(map(_decode_measure_property, properties["qubits"]))
         prop_name_map["measure"] = {}
         for qubit, measure_prop in enumerate(measure_props):
-            if not backend_properties.is_qubit_operational(qubit):
+            if qubit in faulty_qubits:
                 continue
             qubits = (qubit,)
             prop_name_map["measure"][qubits] = measure_prop
+
+    # Special case for real IBM backend. They don't have delay in gate configuration.
+    if "delay" not in prop_name_map:
+        prop_name_map["delay"] = {
+            (q,): None
+            for q in range(configuration.num_qubits)
+            if q not in faulty_qubits
+        }
 
     # Define pulse qobj converter and command sequence for lazy conversion
     if pulse_defaults:
@@ -220,7 +224,7 @@ def target_from_server_data(
         for cmd in map(Command.from_dict, pulse_defaults["cmd_def"]):
             name = cmd.name
             qubits = tuple(cmd.qubits)
-            if any(qubit in faulty_qubits for qubit in qubits):
+            if (name, qubits) in faulty_ops:
                 continue
             if name not in all_instructions or qubits not in prop_name_map[name]:
                 logger.info(
@@ -362,29 +366,37 @@ def _decode_qubit_property(qubit_specs: List[Dict]) -> IBMQubitProperties:
     in_data = {}
     for spec in qubit_specs:
         name = spec["name"]
-        if name in IBMQubitProperties.__slots__:
+        if name == "operational":
+            in_data[name] = bool(spec["value"])
+        elif name in IBMQubitProperties.__slots__:
             in_data[name] = apply_prefix(
                 value=spec["value"], unit=spec.get("unit", None)
             )
     return IBMQubitProperties(**in_data)  # type: ignore[no-untyped-call]
 
 
-def _decode_instruction_property(gate_spec: GateSchema) -> InstructionProperties:
+def _decode_instruction_property(
+    gate_spec: GateSchema,
+) -> Tuple[InstructionProperties, bool]:
     """Decode gate property data to generate InstructionProperties instance.
 
     Args:
         gate_spec: List of gate property dictionary.
 
     Returns:
-        An ``InstructionProperties`` instance.
+        An ``InstructionProperties`` instance and a boolean value representing
+        if this gate is operational.
     """
     in_data = {}
+    operational = True
     for param in gate_spec.parameters:
         if param.name == "gate_error":
             in_data["error"] = param.value
         if param.name == "gate_length":
             in_data["duration"] = apply_prefix(value=param.value, unit=param.unit)
-    return InstructionProperties(**in_data)
+        if param.name == "operational" and not param.value:
+            operational = bool(param.value)
+    return InstructionProperties(**in_data), operational
 
 
 def _decode_measure_property(qubit_specs: List[Dict]) -> InstructionProperties:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR is followup of #603 . The another PR has a bug in filtering mechanism and introduced performance regression due to Qiskit `BackendProperty` model instantiation.

This PR

![image](https://user-images.githubusercontent.com/39517270/236590224-a8d892d3-9752-45c6-a44a-d885dac70be0.png)

fd03d283e24773913c568c4d1832d157ba6eee7c

![image](https://user-images.githubusercontent.com/39517270/236590243-490d22e0-dc83-4660-8b46-d85529218e91.png)


### Details and comments

fd03d283e24773913c568c4d1832d157ba6eee7c

![image](https://user-images.githubusercontent.com/39517270/236590308-a2edb879-8eee-4bf4-a1f1-47bf8d5d8d7f.png)

Faulty instruction entries still exist. Since all entries are initialized with None according to the gate configuration, avoiding (`continue`) registration of instruction property doesn't remove faulty entries.
https://github.com/Qiskit/qiskit-ibm-provider/blob/952b599ecc0beac57809fc6cd91628ee4bb64a71/qiskit_ibm_provider/utils/json_decoder.py#L163-L168

This initialization is convenient, because gate coupling map is usually ascending order in qubit index, while `properties["gates"]` are random ordering (especially two qubit entries). 