### PR TITLE
improve documentation for meas_level and a small foramtting issue

### DIFF
--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -389,12 +389,19 @@ class IBMBackend(Backend):
             meas_lo_freq: List of default measurement LO frequencies in Hz. Will be overridden
                 by ``schedule_los`` if set.
             schedule_los: Experiment LO configurations, frequencies are given in Hz.
-            meas_level: Set the appropriate level of the measurement output for pulse experiments.
-            meas_return: Level of measurement data for the backend to return.
+            meas_level: Level of the measurement output for pulse experiments. See
+                `OpenPulse specification <https://arxiv.org/pdf/1809.03452.pdf>`_ for details:
 
-                For ``meas_level`` 0 and 1:
+                * ``0``, measurements of the raw signal (the measurement output pulse envelope)
+                * ``1``, measurement kernel is selected (a complex number obtained after applying the
+                  measurement kernel to the measurement output signal)
+                * ``2`` (default), a discriminator is selected and the qubit state is stored (0 or 1)
+
+            meas_return: Level of measurement data for the backend to return. For ``meas_level`` 0 and 1:
+
                 * ``single`` returns information from every shot.
                 * ``avg`` returns average measurement output (averaged over number of shots).
+
             rep_delay: Delay between programs in seconds. Only supported on certain
                 backends (if ``backend.configuration().dynamic_reprate_enabled=True``).
                 If supported, ``rep_delay`` must be from the range supplied


### PR DESCRIPTION
Currently, the documentation on `meas_level` is a bit obscure:
<img width="770" src="https://github.com/Qiskit/qiskit-ibm-provider/assets/766693/aa6f4ba8-2401-4d12-8448-c37c3921e8f5">
(unrelated, but there is also a formatting issue in `meas_return`)

This PR introduces more detail for `meas_level` and fixes `meas_return`:
<img width="784"  src="https://github.com/Qiskit/qiskit-ibm-provider/assets/766693/4285232d-931f-4536-afcf-d39ce767e5bb">

Thanks Danya for bring this is up in [`#qiskit-101` in Slack](https://qisk.it/join-slack)!
