### PR TITLE
Allow retrieval of backends even if a configuration is missing 

### DIFF
--- a/qiskit_ibm_provider/ibm_backend_service.py
+++ b/qiskit_ibm_provider/ibm_backend_service.py
@@ -688,27 +688,31 @@ class IBMBackendService:
         Raises:
             QiskitBackendNotFoundError: if the backend is not in the hgp passed in.
         """
-        if not instance:
-            for hgp in hgps:
-                if config.backend_name in hgp.backends:
-                    instance = to_instance_format(hgp._hub, hgp._group, hgp._project)
-                    break
+        if config:
+            if not instance:
+                for hgp in hgps:
+                    if config.backend_name in hgp.backends:
+                        instance = to_instance_format(
+                            hgp._hub, hgp._group, hgp._project
+                        )
+                        break
 
-        elif (
-            config.backend_name
-            not in self._provider._get_hgp(instance=instance).backends
-        ):
-            raise QiskitBackendNotFoundError(
-                f"Backend {config.backend_name} is not in "
-                f"{instance}: please try a different hub/group/project."
+            elif (
+                config.backend_name
+                not in self._provider._get_hgp(instance=instance).backends
+            ):
+                raise QiskitBackendNotFoundError(
+                    f"Backend {config.backend_name} is not in "
+                    f"{instance}: please try a different hub/group/project."
+                )
+
+            return ibm_backend.IBMBackend(
+                instance=instance,
+                configuration=config,
+                api_client=AccountClient(self._provider._client_params),
+                provider=self._provider,
             )
-
-        return ibm_backend.IBMBackend(
-            instance=instance,
-            configuration=config,
-            api_client=AccountClient(self._provider._client_params),
-            provider=self._provider,
-        )
+        return None
 
     @staticmethod
     def _deprecated_backend_names() -> Dict[str, str]:

--- a/releasenotes/notes/missing-backend-config-c61c2dd200502c00.yaml
+++ b/releasenotes/notes/missing-backend-config-c61c2dd200502c00.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Allow for users to retrieve all backends even if one of the backends has a missing 
+    configuration. The backend without a configuration will not be returned. 
+

--- a/test/integration/test_filter_backends.py
+++ b/test/integration/test_filter_backends.py
@@ -128,3 +128,19 @@ class TestBackendFilters(IBMTestCase):
         filtered = self.dependencies.provider.backends(dynamic_circuits=True)
         for backend in filtered:
             self.assertTrue("qasm3" in backend.configuration().supported_features)
+
+    def test_backends_no_config(self):
+        """Test retrieving backends when a config is missing."""
+        backends = self.dependencies.provider.backends(
+            instance=self.dependencies.instance
+        )
+        configs = self.dependencies.provider.backend._backend_configs
+        configs["test_backend"] = None
+        backend_names = [backend.name for backend in backends]
+
+        for config in configs.values():
+            backend = self.dependencies.provider.backend._create_backend_obj(
+                config, instance=self.dependencies.instance
+            )
+            if backend:
+                self.assertTrue(backend.name in backend_names)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The same will have to be done in qiskit-ibm-runtime

### Details and comments


