### PR TITLE
Remove table of contents from tutorials

### DIFF
--- a/docs/tutorials/1_the_ibm_quantum_account.ipynb
+++ b/docs/tutorials/1_the_ibm_quantum_account.ipynb
@@ -39,26 +39,6 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-08-10T11:26:18.728475Z",
-     "start_time": "2019-08-10T11:26:18.724151Z"
-    }
-   },
-   "source": [
-    "## Table of contents\n",
-    "\n",
-    "1) [The Account](#account)\n",
-    "\n",
-    "\n",
-    "2) [Backends](#backends)\n",
-    "    \n",
-    "    \n",
-    "3) [Jobs](#jobs)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## The Account <a name='account'></a>\n",

--- a/docs/tutorials/2_jupyter_tools.ipynb
+++ b/docs/tutorials/2_jupyter_tools.ipynb
@@ -52,18 +52,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Table of contents\n",
-    "\n",
-    "1) [IBM Quantum Dashboard](#dashboard)\n",
-    "\n",
-    "\n",
-    "2) [Backend Details](#details)\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "To start, load your IBM Quantum account:"
    ]
   },

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,7 +24,7 @@ qiskit-ibmq-provider>=0.19.2
 
 # Documentation
 jupyter-sphinx
-nbsphinx
+nbsphinx>=0.9.2
 Sphinx>=5.3.0
 sphinx-tabs>=1.1.11
 sphinx-automodapi


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

The references started breaking due to nbsphinx 0.9.2 changes how references work.

But these table of contents weren't necessary to begin with. Sphinx already generates a Page Table of Contents:

<img width="188" alt="Screenshot 2023-05-25 at 10 30 12 AM" src="https://github.com/Qiskit/qiskit-ibm-provider/assets/14852634/af5e0d0e-caaf-4b84-9ba7-7c1ae2fef172">

I suspect that this was a bad pattern introduced into Qiskit repositories before qiskit_sphinx_theme was using Pytorch, if the original theme didn't have a Page Table of Contents already.