### PR TITLE
Fix to prevent infinite recursion in __getattr__

### DIFF
--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -231,7 +231,7 @@ class IBMBackend(Backend):
         does not yet exist on IBMBackend class.
         """
         # Prevent recursion since these properties are accessed within __getattr__
-        if name in ["_properties", "_defaults", "_target"]:
+        if name in ["_properties", "_defaults", "_target", "_configuration"]:
             raise AttributeError(
                 "'{}' object has no attribute '{}'".format(
                     self.__class__.__name__, name


### PR DESCRIPTION
I'm trying to deep-copy a backend. But then I enter an infinite recursion:
```
  File "/home/yaelbh/miniconda3/envs/env1/lib/python3.9/copy.py", line 172, in deepcopy
    y = _reconstruct(x, memo, *rv)
  File "/home/yaelbh/miniconda3/envs/env1/lib/python3.9/copy.py", line 271, in _reconstruct
    if hasattr(y, '__setstate__'):
  File "/home/yaelbh/miniconda3/envs/env1/lib/python3.9/site-packages/qiskit_ibm_provider/ibm_backend.py", line 247, in __getattr__
    return self._configuration.__getattribute__(name)
  File "/home/yaelbh/miniconda3/envs/env1/lib/python3.9/site-packages/qiskit_ibm_provider/ibm_backend.py", line 247, in __getattr__
    return self._configuration.__getattribute__(name)
  File "/home/yaelbh/miniconda3/envs/env1/lib/python3.9/site-packages/qiskit_ibm_provider/ibm_backend.py", line 247, in __getattr__
    return self._configuration.__getattribute__(name)
  [Previous line repeated 987 more times]
```

Printing `name` at the beginning of `__getattr__`:
```
__deepcopy__
__getstate__
__setstate__
_configuration
_configuration
_configuration
_configuration
_configuration
_configuration
_configuration
... and so on
```

I don't understand why `deepcopy` reaches `__getattr__`, and why the recursion occurs. I noticed that the fix suggested in this PR seems to work: the backend's copy is created without exceptions and runs correctly. However, since I don't really understand what's going on, I can't guarantee that the copying worked flawlessly (and that in general adding `_configuration` to the list does not break anything).
