### PR TITLE
Fix circuit metadata serialization bug

### DIFF
--- a/qiskit_ibm_provider/utils/json.py
+++ b/qiskit_ibm_provider/utils/json.py
@@ -212,7 +212,7 @@ class RuntimeEncoder(json.JSONEncoder):
         if isinstance(obj, QuantumCircuit):
             value = _serialize_and_encode(
                 data=obj,
-                serializer=lambda buff, data: dump(data, buff),  # type: ignore[no-untyped-call]
+                serializer=lambda buff, data: dump(data, buff, RuntimeEncoder),  # type: ignore[no-untyped-call]
             )
             return {"__type__": "QuantumCircuit", "__value__": value}
         if isinstance(obj, Parameter):

--- a/qiskit_ibm_provider/utils/json.py
+++ b/qiskit_ibm_provider/utils/json.py
@@ -212,7 +212,7 @@ class RuntimeEncoder(json.JSONEncoder):
         if isinstance(obj, QuantumCircuit):
             value = _serialize_and_encode(
                 data=obj,
-                serializer=lambda buff, data: dump(data, buff, RuntimeEncoder),  # type: ignore[no-untyped-call]
+                serializer=lambda buff, data: dump(data, buff),  # type: ignore[no-untyped-call]
             )
             return {"__type__": "QuantumCircuit", "__value__": value}
         if isinstance(obj, Parameter):

--- a/qiskit_ibm_provider/utils/json.py
+++ b/qiskit_ibm_provider/utils/json.py
@@ -212,7 +212,9 @@ class RuntimeEncoder(json.JSONEncoder):
         if isinstance(obj, QuantumCircuit):
             value = _serialize_and_encode(
                 data=obj,
-                serializer=lambda buff, data: dump(data, buff),  # type: ignore[no-untyped-call]
+                serializer=lambda buff, data: dump(
+                    data, buff, RuntimeEncoder
+                ),  # type: ignore[no-untyped-call]
             )
             return {"__type__": "QuantumCircuit", "__value__": value}
         if isinstance(obj, Parameter):

--- a/releasenotes/notes/fix-serialization-bug-adabc48b48cc1ccd.yaml
+++ b/releasenotes/notes/fix-serialization-bug-adabc48b48cc1ccd.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixed an issue where circuit metadata was not being serialized correctly 
+    resulting in a type error.
+

--- a/test/unit/test_serialization.py
+++ b/test/unit/test_serialization.py
@@ -13,12 +13,13 @@
 """Test serializing and deserializing data sent to the server."""
 
 import json
-
+import numpy as np
 from qiskit import assemble
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 from qiskit.circuit import Parameter
 
 from qiskit_ibm_provider.utils.json_encoder import IBMJsonEncoder
+from qiskit_ibm_provider.utils.json import RuntimeEncoder
 from ..ibm_test_case import IBMTestCase
 
 
@@ -26,7 +27,7 @@ class TestSerialization(IBMTestCase):
     """Test data serialization."""
 
     def test_exception_message(self):
-        """Test executing job with Parameter in methadata."""
+        """Test executing job with Parameter in metadata."""
         quantum_register = QuantumRegister(1)
         classical_register = ClassicalRegister(1)
         my_circ_str = "test_metadata"
@@ -65,3 +66,12 @@ class TestSerialization(IBMTestCase):
             '{"t1": 1, "null": null, "a": 0.2, "list": [1, 2, {"ld": 1, "2": 3, "alfa": 0.1}]}',
             IBMJsonEncoder().encode(test_dir),
         )
+
+    def test_circuit_metadata(self):
+        """Test serializing circuit metadata."""
+
+        circ = QuantumCircuit(1)
+        circ.metadata = {"test": np.arange(0, 10)}
+        payload = {"circuits": [circ]}
+
+        self.assertTrue(json.dumps(payload, cls=RuntimeEncoder))


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Originally reported in the pec-runtime repo - circuit metadata was not being serialized correctly 

`RuntimeEncoder` isn't passed in as the `metadata_serializer` param [here](https://github.com/Qiskit/qiskit-ibm-provider/blob/main/qiskit_ibm_provider/utils/json.py#L215) so `write_circuit` is using the default JSON encoder


fixes #582 

### Details and comments


