### PR TITLE
Fix JSONDecoder 'encoding' bug 

### DIFF
--- a/qiskit_ibm_provider/api/rest/program_job.py
+++ b/qiskit_ibm_provider/api/rest/program_job.py
@@ -53,7 +53,10 @@ class ProgramJob(RestAdapterBase):
         Returns:
             JSON response.
         """
-        return self.session.get(self.get_url("self")).json(cls=RuntimeDecoder)
+        try:
+            return self.session.get(self.get_url("self")).json(cls=RuntimeDecoder)
+        except:
+            return self.session.get(self.get_url("self")).json()
 
     def job_type(self) -> str:
         """Return job type:

--- a/qiskit_ibm_provider/api/rest/program_job.py
+++ b/qiskit_ibm_provider/api/rest/program_job.py
@@ -53,10 +53,7 @@ class ProgramJob(RestAdapterBase):
         Returns:
             JSON response.
         """
-        try:
-            return self.session.get(self.get_url("self")).json(cls=RuntimeDecoder)
-        except:
-            return self.session.get(self.get_url("self")).json()
+        return self.session.get(self.get_url("self")).json(cls=RuntimeDecoder)
 
     def job_type(self) -> str:
         """Return job type:

--- a/qiskit_ibm_provider/utils/json.py
+++ b/qiskit_ibm_provider/utils/json.py
@@ -261,6 +261,7 @@ class RuntimeDecoder(json.JSONDecoder):
     """JSON Decoder used by runtime service."""
 
     def __init__(self, *args: Any, **kwargs: Any):
+        kwargs.pop("encoding", None)
         super().__init__(object_hook=self.object_hook, *args, **kwargs)
         self.__parameter_vectors: Dict[str, Tuple[ParameterVector, set]] = {}
         self.__read_parameter_expression = (

--- a/qiskit_ibm_provider/utils/json.py
+++ b/qiskit_ibm_provider/utils/json.py
@@ -212,7 +212,7 @@ class RuntimeEncoder(json.JSONEncoder):
         if isinstance(obj, QuantumCircuit):
             value = _serialize_and_encode(
                 data=obj,
-                serializer=lambda buff, data: dump(data, buff),  # type: ignore[no-untyped-call]
+                serializer=lambda buff, data: dump(data, buff, RuntimeEncoder),  # type: ignore[no-untyped-call]
             )
             return {"__type__": "QuantumCircuit", "__value__": value}
         if isinstance(obj, Parameter):

--- a/qiskit_ibm_provider/utils/json.py
+++ b/qiskit_ibm_provider/utils/json.py
@@ -212,7 +212,7 @@ class RuntimeEncoder(json.JSONEncoder):
         if isinstance(obj, QuantumCircuit):
             value = _serialize_and_encode(
                 data=obj,
-                serializer=lambda buff, data: dump(data, buff, RuntimeEncoder),  # type: ignore[no-untyped-call]
+                serializer=lambda buff, data: dump(data, buff),  # type: ignore[no-untyped-call]
             )
             return {"__type__": "QuantumCircuit", "__value__": value}
         if isinstance(obj, Parameter):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This has been reported 3 times now - #528, #647, and on slack. I have been unable to replicate this issue but this was a suggested fix. 

```JSONDecoder.__init__() got an unexpected keyword argument 'encoding'```

The keyword argument `encoding` was removed in python 3.9 https://docs.python.org/3/library/json.html#json.loads but I'm not sure if that's related to this error (2 of the users were using python 3.10, 1 was using python 3.8). 

thoughts @jyu00 @merav-aharoni?  

Update: figured it out, explained in comment below 

### Details and comments


