### PR TITLE
Fix backend filters bug

### DIFF
--- a/qiskit_ibm_provider/ibm_backend_service.py
+++ b/qiskit_ibm_provider/ibm_backend_service.py
@@ -168,7 +168,8 @@ class IBMBackendService:
                 self._backends[name] = self._create_backend_obj(
                     self._backend_configs[name], instance, self._provider._get_hgps()
                 )
-            backends.append(self._backends[name])
+            if self._backends[name]:
+                backends.append(self._backends[name])
         elif instance:
             hgp = self._provider._get_hgp(instance=instance)
             for backend_name in hgp.backends.keys():
@@ -180,7 +181,8 @@ class IBMBackendService:
                     self._backends[backend_name] = self._create_backend_obj(
                         self._backend_configs[backend_name], instance
                     )
-                backends.append(self._backends[backend_name])
+                if self._backends[backend_name]:
+                    backends.append(self._backends[backend_name])
         else:
             hgps = self._provider._get_hgps()
             for backend_name, backend_config in self._backends.items():
@@ -189,7 +191,8 @@ class IBMBackendService:
                     self._backends[backend_name] = self._create_backend_obj(
                         self._backend_configs[backend_name], hgps=hgps
                     )
-                backends.append(self._backends[backend_name])
+                if self._backends[backend_name]:
+                    backends.append(self._backends[backend_name])
         # Special handling of the `name` parameter, to support alias resolution.
         if name:
             aliases = self._aliased_backend_names()

--- a/qiskit_ibm_provider/utils/json.py
+++ b/qiskit_ibm_provider/utils/json.py
@@ -212,7 +212,7 @@ class RuntimeEncoder(json.JSONEncoder):
         if isinstance(obj, QuantumCircuit):
             value = _serialize_and_encode(
                 data=obj,
-                serializer=lambda buff, data: dump(data, buff),  # type: ignore[no-untyped-call]
+                serializer=lambda buff, data: dump(data, buff, RuntimeEncoder),  # type: ignore[no-untyped-call]
             )
             return {"__type__": "QuantumCircuit", "__value__": value}
         if isinstance(obj, Parameter):

--- a/qiskit_ibm_provider/utils/json.py
+++ b/qiskit_ibm_provider/utils/json.py
@@ -212,7 +212,7 @@ class RuntimeEncoder(json.JSONEncoder):
         if isinstance(obj, QuantumCircuit):
             value = _serialize_and_encode(
                 data=obj,
-                serializer=lambda buff, data: dump(data, buff, RuntimeEncoder),  # type: ignore[no-untyped-call]
+                serializer=lambda buff, data: dump(data, buff),  # type: ignore[no-untyped-call]
             )
             return {"__type__": "QuantumCircuit", "__value__": value}
         if isinstance(obj, Parameter):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Same as https://github.com/Qiskit/qiskit-ibm-runtime/pull/882

I missed this in #631 - when a backend like ibm_cusco has no configuration, we return None but this leads to issues when filters like simulator=True is used.

### Details and comments


