### PR TITLE
Fixed bug in deepcopy of IBMBackend

### DIFF
--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -231,7 +231,7 @@ class IBMBackend(Backend):
         does not yet exist on IBMBackend class.
         """
         # Prevent recursion since these properties are accessed within __getattr__
-        if name in ["_properties", "_defaults", "_target"]:
+        if name in ["_properties", "_defaults", "_target", "_configuration"]:
             raise AttributeError(
                 "'{}' object has no attribute '{}'".format(
                     self.__class__.__name__, name

--- a/releasenotes/notes/backend_deepcopy-032282246b52e391.yaml
+++ b/releasenotes/notes/backend_deepcopy-032282246b52e391.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed infinite recursion when attempting to deepcopy an IBMBackend.
+

--- a/test/unit/test_backend.py
+++ b/test/unit/test_backend.py
@@ -11,7 +11,7 @@
 # that they have been altered from the originals.
 
 """Tests for the backend functions."""
-
+import copy
 from datetime import datetime
 from unittest import mock
 import warnings
@@ -318,3 +318,9 @@ class TestBackend(IBMTestCase):
             backend.run(circuits=qasm3_circs, dynamic=True)
 
         mock_run.assert_called_once()
+
+    def test_deepcopy(self):
+        """Test that deepcopy of a backend works properly"""
+        backend = self._create_dc_test_backend()
+        backend_copy = copy.deepcopy(backend)
+        self.assertEqual(backend_copy.name, backend.name)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
`copy.deepcopy(IBMBackend)` was failing due to infinite recursion. Fixed that bug.
### Details and comments
Fixes #654.
See also #646.

