### PR TITLE
Raise exception when num circuits exceeds backend max_circuits

### DIFF
--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -822,7 +822,8 @@ class IBMBackend(Backend):
         )
         if len(circuits) > self._max_circuits:
             raise IBMBackendValueError(
-                f"Number of circuits, {len(circuits)} exceeds the the maximum for this backend, {self._max_circuits})"
+                f"Number of circuits, {len(circuits)} exceeds the "
+                f"maximum for this backend, {self._max_circuits})"
             )
         for circ in circuits:
             if isinstance(circ, Schedule):

--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -820,6 +820,10 @@ class IBMBackend(Backend):
             "https://qiskit.org/documentation/tutorials/circuits_advanced/05_pulse_gates.html` "
             "on how to use pulse gates."
         )
+        if len(circuits) > self._max_circuits:
+            raise IBMBackendValueError(
+                f"Number of circuits {len(circuits)} exceeds backend._max_circuits({self._max_circuits})"
+            )
         for circ in circuits:
             if isinstance(circ, Schedule):
                 raise IBMBackendValueError(schedule_error_msg)

--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -822,7 +822,7 @@ class IBMBackend(Backend):
         )
         if len(circuits) > self._max_circuits:
             raise IBMBackendValueError(
-                f"Number of circuits {len(circuits)} exceeds backend._max_circuits({self._max_circuits})"
+                f"Number of circuits, {len(circuits)} exceeds the the maximum for this backend, {self._max_circuits})"
             )
         for circ in circuits:
             if isinstance(circ, Schedule):

--- a/releasenotes/notes/max_circuits-066b5eeebfe537a4.yaml
+++ b/releasenotes/notes/max_circuits-066b5eeebfe537a4.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Raise an exception if the number of circuits passed to IBMBackend.run() exceeds
+    IBMBackend._max_circuits.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Raise and exception when the number of circuits passed to `IBMBackend.run()` exceeds `IBMBackend._max_circuits`.


### Details and comments
Fixes #667 

