### PR TITLE
Remove unused Sphinx extensions breaking notebook gallery

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,7 +64,6 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
     'sphinx.ext.extlinks',
-    'sphinx_tabs.tabs',
     'jupyter_sphinx',
     'sphinx_autodoc_typehints',
     'reno.sphinxext',

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,8 +26,6 @@ qiskit-ibmq-provider>=0.19.2
 jupyter-sphinx
 nbsphinx>=0.9.2
 Sphinx>=5.3.0
-sphinx-tabs>=1.1.11
-sphinx-automodapi
 sphinx-autodoc-typehints<=1.19.2
 reno>=2.11.0
-qiskit-sphinx-theme~=1.11.1
+qiskit-sphinx-theme~=1.13.1


### PR DESCRIPTION
For some reason, `sphinx_tabs.tabs` results in the CSS for `nbconvert` not being included....This messes up the styling for the notebook gallery.

They look like this:

![Screenshot 2023-07-19 at 11 49 06 AM](https://github.com/Qiskit/qiskit-ibm-provider/assets/14852634/0984ccf4-b4f0-4d31-ae9b-06b62a5f4f41)

But should e.g. be on the same line and have a border:

![Screenshot 2023-07-19 at 11 49 39 AM](https://github.com/Qiskit/qiskit-ibm-provider/assets/14852634/4c02c428-e273-4a26-a038-3918956977de)

(https://github.com/Qiskit/qiskit-ibm-provider/pull/672 will improve the design)

Either way, they are unused packages so should be removed.