### PR TITLE
Add documentation on integration passmanagers with Qiskit

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,7 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
     'sphinx.ext.extlinks',
+    'sphinx.ext.intersphinx',
     'jupyter_sphinx',
     'sphinx_autodoc_typehints',
     'reno.sphinxext',
@@ -62,6 +63,10 @@ extensions = [
     "qiskit_sphinx_theme",
 ]
 templates_path = ['_templates']
+
+intersphinx_mapping = {
+    "qiskit": ("https://qiskit.org/documentation/", None),
+}
 
 nbsphinx_timeout = 300
 nbsphinx_execute = "never"


### PR DESCRIPTION
### Summary

In general, it's safest (and more efficient) to run all defined pass sets on a circuit input using a unifying `PassManager`, rather than doing it in separate stages.  This updates the scheduling documentation to illustrate the process.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### Details and comments

Requested by @taalexander in Slack.
