### PR TITLE
Fix staggered dynamical decoupling for disjoint coupling maps

### DIFF
--- a/qiskit_ibm_provider/transpiler/passes/scheduling/dynamical_decoupling.py
+++ b/qiskit_ibm_provider/transpiler/passes/scheduling/dynamical_decoupling.py
@@ -251,10 +251,8 @@ class PadDynamicalDecoupling(BlockBasePadder):
 
         if self._coupling_map:
             physical_qubits = [dag.qubits.index(q) for q in dag.qubits]
-            sub_coupling_map = self._coupling_map.reduce(physical_qubits)
-            self._coupling_coloring = rx.graph_greedy_color(
-                sub_coupling_map.graph.to_undirected()
-            )
+            subgraph = self._coupling_map.graph.subgraph(physical_qubits)
+            self._coupling_coloring = rx.graph_greedy_color(subgraph.to_undirected())
             if any(c > 1 for c in self._coupling_coloring.values()):
                 raise TranspilerError(
                     "This circuit topology is not supported for staggered dynamical decoupling."

--- a/releasenotes/notes/fix-disjoint-coupling-map-1d4a011f2bb2a7c3.yaml
+++ b/releasenotes/notes/fix-disjoint-coupling-map-1d4a011f2bb2a7c3.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Replace coupling_map.reduce(nodes) with coupling_map.graph.subgraph(nodes
+    to apply DD on a disjoint coupling map. See discussion in
+    https://github.com/Qiskit/qiskit-terra/pull/9710

--- a/test/unit/transpiler/passes/scheduling/test_dynamical_decoupling.py
+++ b/test/unit/transpiler/passes/scheduling/test_dynamical_decoupling.py
@@ -969,3 +969,18 @@ class TestPadDynamicalDecoupling(ControlFlowTestCase):
 
         with self.assertRaises(TranspilerError):
             pm.run(self.ghz4)
+
+    def test_disjoint_coupling_map(self):
+        """Test staggered DD with disjoint coupling map."""
+        dd_sequence = [XGate(), XGate()]
+        pm = PassManager(
+            [
+                ASAPScheduleAnalysis(self.durations),
+                PadDynamicalDecoupling(
+                    self.durations,
+                    dd_sequence,
+                    coupling_map=CouplingMap([[0, 1], [1, 2], [2, 3], [4, 5]]),
+                ),
+            ]
+        )
+        pm.run(self.ghz4)

--- a/test/unit/transpiler/passes/scheduling/test_dynamical_decoupling.py
+++ b/test/unit/transpiler/passes/scheduling/test_dynamical_decoupling.py
@@ -23,6 +23,7 @@ from qiskit.quantum_info import Operator
 from qiskit.transpiler.passmanager import PassManager
 from qiskit.transpiler.exceptions import TranspilerError
 from qiskit.transpiler.coupling import CouplingMap
+from qiskit.converters import circuit_to_dag
 
 from qiskit_ibm_provider.transpiler.passes.scheduling.dynamical_decoupling import (
     PadDynamicalDecoupling,
@@ -972,6 +973,13 @@ class TestPadDynamicalDecoupling(ControlFlowTestCase):
 
     def test_disjoint_coupling_map(self):
         """Test staggered DD with disjoint coupling map."""
+        qc = QuantumCircuit(5)
+        for q in range(5):
+            qc.x(q)
+        qc.barrier()
+        for q in range(5):
+            qc.delay(1600, q)
+        qc.barrier()
         dd_sequence = [XGate(), XGate()]
         pm = PassManager(
             [
@@ -979,8 +987,18 @@ class TestPadDynamicalDecoupling(ControlFlowTestCase):
                 PadDynamicalDecoupling(
                     self.durations,
                     dd_sequence,
-                    coupling_map=CouplingMap([[0, 1], [1, 2], [2, 3], [4, 5]]),
+                    coupling_map=CouplingMap([[0, 1], [1, 2], [3, 4]]),
                 ),
             ]
         )
-        pm.run(self.ghz4)
+        dd_qc = pm.run(qc)
+
+        # ensure that delays for nearest neighbors are staggered
+        dag = circuit_to_dag(dd_qc)
+        delays = dag.op_nodes(Delay)
+        delay_dict = {q_ind: [] for q_ind in range(5)}
+        for delay in delays:
+            delay_dict[dag.find_bit(delay.qargs[0]).index] += [delay.op.duration]
+        self.assertNotEqual(delay_dict[0], delay_dict[1])
+        self.assertNotEqual(delay_dict[1], delay_dict[2])
+        self.assertNotEqual(delay_dict[3], delay_dict[4])

--- a/test/unit/transpiler/passes/scheduling/test_dynamical_decoupling.py
+++ b/test/unit/transpiler/passes/scheduling/test_dynamical_decoupling.py
@@ -1002,3 +1002,4 @@ class TestPadDynamicalDecoupling(ControlFlowTestCase):
         self.assertNotEqual(delay_dict[0], delay_dict[1])
         self.assertNotEqual(delay_dict[1], delay_dict[2])
         self.assertNotEqual(delay_dict[3], delay_dict[4])
+        self.assertEqual(delay_dict[0], delay_dict[2])


### PR DESCRIPTION
### Summary

Staggered dynamical decoupling uses the `backend.coupling_map()` to classify the qubits into 2 sets with different delays. 
Due to a check in the [reduce ](https://github.com/mtreinish/qiskit-core/blob/master/qiskit/transpiler/coupling.py#L213) method of a coupling map, this was failing if not all qubits are connected. 

### Details and comments

This PR circumvents the issue by getting the subgraph directly as suggested in https://github.com/Qiskit/qiskit-terra/pull/9710#issuecomment-1516851167