### PR TITLE
remove deploy documentation to /documentation

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -31,6 +31,3 @@ pwd
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 echo "Pushing built docs to qiskit.org/ecosystem"
 rclone sync --progress ./docs/_build/html IBMCOS:qiskit-org-web-resources/ecosystem/ibm-provider
-
-# Push to qiskit.org/documentation
-rclone sync --progress ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation/partners/qiskit_ibm_provider


### PR DESCRIPTION
Follow up on https://github.com/Qiskit/qiskit-ibm-provider/pull/544

The documentation is correctly deployed in https://qiskit.org/ecosystem/ibm-provider/ and the https://qiskit.org/documentation/partners/qiskit_ibm_provider redirect is working. So, no need to upload to /documentation anymore.