### PR TITLE
Fix typing in `DAGCircuit.apply_operation_back`

### DIFF
--- a/qiskit_ibm_provider/transpiler/passes/scheduling/block_base_padder.py
+++ b/qiskit_ibm_provider/transpiler/passes/scheduling/block_base_padder.py
@@ -567,8 +567,8 @@ class BlockBasePadder(TransformationPass):
         block_idx: int,
         t_start: int,
         oper: Instruction,
-        qubits: Union[Qubit, List[Qubit]],
-        clbits: Optional[Union[Clbit, List[Clbit]]] = None,
+        qubits: Union[Qubit, Iterable[Qubit]],
+        clbits: Union[Clbit, Iterable[Clbit]] = (),
     ) -> DAGNode:
         """Add new operation to DAG with scheduled information.
 
@@ -589,9 +589,7 @@ class BlockBasePadder(TransformationPass):
         if isinstance(clbits, Clbit):
             clbits = [clbits]
 
-        new_node = self._block_dag.apply_operation_back(
-            oper, qargs=qubits, cargs=clbits
-        )
+        new_node = self._block_dag.apply_operation_back(oper, qubits, clbits)
         self.property_set["node_start_time"][new_node] = (block_idx, t_start)
         return new_node
 


### PR DESCRIPTION
### Summary

It is not valid typing (per the documentation) to pass `None` to `DAGCircuit.apply_operation_back` in either the `qargs` or `cargs` field, though this has been silently accepted previously to support mistaken code in the Terra schedulers, which this repository has inherited.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Details and comments

