### PR TITLE
Remove `qiskit-ibmq-provider` from `requirements-dev.txt`

### DIFF
--- a/qiskit_ibm_provider/ibm_backend_service.py
+++ b/qiskit_ibm_provider/ibm_backend_service.py
@@ -262,7 +262,7 @@ class IBMBackendService:
             descending: If ``True``, return the jobs in descending order of the job
                 creation date (i.e. newest first) until the limit is reached.
             instance: The provider in the hub/group/project format.
-            legacy: If ``True``, only retrieve jobs run from the deprecated ``qiskit-ibmq-provider``.
+            legacy: If ``True``, only retrieve jobs run from the archived ``qiskit-ibmq-provider``.
             Otherwise, only retrieve jobs run from ``qiskit-ibm-provider``.
 
         Returns:
@@ -383,7 +383,7 @@ class IBMBackendService:
             skip: Starting index for the job retrieval.
             descending: If ``True``, return the jobs in descending order of the job
                 creation date (i.e. newest first) until the limit is reached.
-            legacy: Filter to only retrieve jobs run from the deprecated `qiskit-ibmq-provider`.
+            legacy: Filter to only retrieve jobs run from the archived ``qiskit-ibmq-provider``.
 
         Returns:
             A list of raw API response.
@@ -435,7 +435,7 @@ class IBMBackendService:
             job_info: Job info in dictionary format.
             raise_error: Whether to raise an exception if `job_info` is in
                 an invalid format.
-            legacy: Filter to only retrieve jobs run from the deprecated `qiskit-ibmq-provider`.
+            legacy: Filter to only retrieve jobs run from the archived ``qiskit-ibmq-provider``.
 
         Returns:
             Circuit job restored from the data, or ``None`` if format is invalid.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -20,7 +20,6 @@ coverage>=6.3
 scikit-learn>=0.20.0
 ddt>=1.2.0,!=1.4.0,!=1.4.3
 pylatexenc>=1.4
-qiskit-ibmq-provider>=0.19.2
 
 # Documentation
 jupyter-sphinx

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering",
     ],
-    keywords="qiskit sdk quantum api ibmq",
+    keywords="qiskit, quantum",
     packages=setuptools.find_packages(exclude=["test*"]),
     install_requires=REQUIREMENTS,
     include_package_data=True,


### PR DESCRIPTION
Removing `qiskit-ibmq-provider` from `requirements-dev.txt`, as it is unmaintained since July 2023.