### PR TITLE
Bit.index is deprecated since Apr 2021

### DIFF
--- a/qiskit_ibm_provider/transpiler/passes/scheduling/dynamical_decoupling.py
+++ b/qiskit_ibm_provider/transpiler/passes/scheduling/dynamical_decoupling.py
@@ -497,7 +497,7 @@ class PadDynamicalDecoupling(BlockBasePadder):
                 return self._alignment * np.floor(values / self._alignment)
 
             if self._coupling_map:
-                if self._coupling_coloring[qubit.index] == 0:
+                if self._coupling_coloring[self._dag.qubits.index(qubit)] == 0:
                     sub_spacings = spacings
                 else:
                     sub_spacings = alt_spacings


### PR DESCRIPTION
### Summary

Removes deprecated (since 0.17, April 2021) `Bit.index` access.

### Details and comments

The PR #563 introduced a `Bit.index` access, which it was deprecated 2 years before. This PR changes the access way to the maintained mechanism.

A bit of the side note, is there any way to control for this kind of injection of deprecated functionality in new PRs?