### PR TITLE
readjust test_convert_id_to_delay

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -88,7 +88,6 @@ disable=arguments-renamed,              # more readable and clear
         too-many-public-methods,        # too verbose
         too-many-statements,            # too verbose
         unnecessary-pass,               # allow for methods with just "pass", for clarity
-        unnecessary-pass,               # allow for methods with just "pass", for clarity
         not-context-manager,            # terra is not fully type-safe
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/.pylintrc
+++ b/.pylintrc
@@ -88,6 +88,8 @@ disable=arguments-renamed,              # more readable and clear
         too-many-public-methods,        # too verbose
         too-many-statements,            # too verbose
         unnecessary-pass,               # allow for methods with just "pass", for clarity
+        unnecessary-pass,               # allow for methods with just "pass", for clarity
+        not-context-manager,            # terra is not fully type-safe
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/test/unit/transpiler/passes/basis/test_convert_id_to_delay.py
+++ b/test/unit/transpiler/passes/basis/test_convert_id_to_delay.py
@@ -68,15 +68,15 @@ class TestConvertIdToDelay(QiskitTestCase):
         """Test if c_if Id gate is converted a c_if delay."""
         qc = QuantumCircuit(1, 1)
 
-        qc.id(0).c_if(0, 1)
+        with qc.if_test((0, 1)):
+            qc.id(0)
 
         pm = PassManager([ConvertIdToDelay(self.durations)])
         transformed = pm.run(qc)
 
         expected = QuantumCircuit(1, 1)
-        expected.delay(160, 0)
-        # Delay does not officially support condition
-        expected.data[0].operation.condition = qc.data[0].operation.condition
+        with expected.if_test((0, 1)):
+            expected.delay(160, 0)
 
         self.assertEqual(expected, transformed)
 


### PR DESCRIPTION
### Summary

Fixes #735

### Details and comments

The test `test.unit.transpiler.passes.basis.test_convert_id_to_delay.TestConvertIdToDelay.test_c_if_id_gate` is a bit hacky. However, if I understand its spirit correctly, they point is to check that `I` gates are converted to `Delay` operators correctly, even inside a condition. 
