### PR TITLE
Exceptions should inherit from Terra where suitable

### DIFF
--- a/qiskit_ibm_provider/qpy/exceptions.py
+++ b/qiskit_ibm_provider/qpy/exceptions.py
@@ -12,10 +12,11 @@
 
 """Exception for errors raised by the pulse module."""
 from typing import Any
-from qiskit.exceptions import QiskitError
+from qiskit.qpy.exceptions import QpyError
+from ..exceptions import IBMError
 
 
-class QpyError(QiskitError):
+class IBMQpyError(QpyError, IBMError):
     """Errors raised by the qpy module."""
 
     def __init__(self, *message: Any):

--- a/qiskit_ibm_provider/visualization/exceptions.py
+++ b/qiskit_ibm_provider/visualization/exceptions.py
@@ -14,6 +14,7 @@
 
 from qiskit.visualization.exceptions import VisualizationError
 
+
 class VisualizationValueError(VisualizationError, ValueError):
     """Value errors raised by the visualization modules."""
 

--- a/qiskit_ibm_provider/visualization/exceptions.py
+++ b/qiskit_ibm_provider/visualization/exceptions.py
@@ -12,14 +12,7 @@
 
 """Exceptions related to the visualization modules."""
 
-from ..exceptions import IBMError
-
-
-class VisualizationError(IBMError):
-    """Base class for errors raised by the visualization modules."""
-
-    pass
-
+from qiskit.visualization.exceptions import VisualizationError
 
 class VisualizationValueError(VisualizationError, ValueError):
     """Value errors raised by the visualization modules."""

--- a/test/unit/mock/fake_account_client.py
+++ b/test/unit/mock/fake_account_client.py
@@ -16,6 +16,7 @@ from datetime import datetime as python_datetime
 from typing import List, Dict, Any, Optional
 
 from qiskit.providers.fake_provider.backends.lima.fake_lima import FakeLima
+from qiskit.providers.exceptions import QiskitBackendNotFoundError
 
 
 class FakeApiBackend:
@@ -81,7 +82,7 @@ class BaseFakeAccountClient:
         for back in self._backends:
             if back.name == backend_name:
                 return back.status.copy()
-        raise ValueError(f"Backend {backend_name} not found")
+        raise QiskitBackendNotFoundError(f"Backend {backend_name} not found")
 
     def backend_properties(
         self, backend_name: str, datetime: Optional[python_datetime] = None
@@ -91,14 +92,14 @@ class BaseFakeAccountClient:
         for back in self._backends:
             if back.name == backend_name:
                 return back.properties.copy()
-        raise ValueError(f"Backend {backend_name} not found")
+        raise QiskitBackendNotFoundError(f"Backend {backend_name} not found")
 
     def backend_pulse_defaults(self, backend_name: str) -> Dict:
         """Return the pulse defaults of the backend."""
         for back in self._backends:
             if back.name == backend_name:
                 return back.defaults.copy()
-        raise ValueError(f"Backend {backend_name} not found")
+        raise QiskitBackendNotFoundError(f"Backend {backend_name} not found")
 
     # Test-only methods.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
I only identified two such exceptions: `RuntimeJobFailureError` should inherit `JobError`, and `QpyError`.
While reviewing the exceptions, I changed the exception type in the `fake_account_client.py`. I thought `QiskitBackendNotFoundError` was more suitable here.
One question I had was what is the purpose of double inheritance from `IBMError`, e.g., `IBMQpyError(QpyError, IBMError)`? 

### Details and comments
See also https://github.com/Qiskit/qiskit-ibm-runtime/pull/1120.

