### PR TITLE
use optional wait to change polling rate

### DIFF
--- a/qiskit_ibm_provider/job/ibm_circuit_job.py
+++ b/qiskit_ibm_provider/job/ibm_circuit_job.py
@@ -641,6 +641,7 @@ class IBMCircuitJob(IBMJob):
     def wait_for_final_state(  # pylint: disable=arguments-differ
         self,
         timeout: Optional[float] = None,
+        wait: int = 3,
     ) -> None:
         """Use the websocket server to wait for the final the state of a job. The server
             will remain open if the job is still running and the connection will be terminated
@@ -665,7 +666,7 @@ class IBMCircuitJob(IBMJob):
                     raise IBMJobTimeoutError(
                         f"Timed out waiting for job to complete after {timeout} secs."
                     )
-                time.sleep(3)
+                time.sleep(wait)
                 status = self.status()
         except futures.TimeoutError:
             raise IBMJobTimeoutError(


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

uses an optional `wait` argument like [JobV1](https://qiskit.org/documentation/stubs/qiskit.providers.JobV1.html#qiskit.providers.JobV1.wait_for_final_state) to change the polling time for the `wait_for_final_state` method.

### Details and comments

defaults to `3` seconds for backwards compatibility
