### PR TITLE
Fix Parameter uuid on serialization

### DIFF
--- a/qiskit_ibm_provider/qpy/binary_io/value.py
+++ b/qiskit_ibm_provider/qpy/binary_io/value.py
@@ -212,8 +212,7 @@ def _read_parameter(file_obj):  # type: ignore[no-untyped-def]
     )
     param_uuid = uuid.UUID(bytes=data.uuid)
     name = file_obj.read(data.name_size).decode(common.ENCODE)
-    param = Parameter.__new__(Parameter, name, uuid=param_uuid)
-    param.__init__(name)  # pylint: disable=unnecessary-dunder-call
+    param = Parameter(name, uuid=param_uuid)
     return param
 
 

--- a/test/unit/test_serialization.py
+++ b/test/unit/test_serialization.py
@@ -106,3 +106,18 @@ class TestSerialization(IBMTestCase):
         self.assertIsInstance(decoded, NoiseModel)
         self.assertEqual(noise_model.noise_qubits, decoded.noise_qubits)
         self.assertEqual(noise_model.noise_instructions, decoded.noise_instructions)
+
+    def test_param(self):
+        """Test encoding and decoding a parameter."""
+        param = Parameter("a")
+        encoded = json.dumps(param, cls=RuntimeEncoder)
+        self.assertIsInstance(encoded, str)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=DeprecationWarning,
+            )
+            decoded = json.loads(encoded, cls=RuntimeDecoder)
+        self.assertIsInstance(decoded, Parameter)
+        self.assertEqual(param.name, decoded.name)
+        self.assertEqual(param._uuid, decoded._uuid)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

When serializing a parameter, uuid data is included. But, the uuid is overwritten with a different value by calling `Parameter.__init__` when deserializing it.
This PR fixes the issue.

### Details and comments

```python
import json
from qiskit_ibm_runtime import RuntimeEncoder, RuntimeDecoder
from qiskit.circuit import Parameter

param = Parameter('a')
print(param, param._uuid)
buf = json.dumps(param, cls=RuntimeEncoder)
param2 = json.loads(buf, cls=RuntimeDecoder)
print(param2, param2._uuid)
```

main branch
```
a 7d8797c6-2fd0-4e69-8af9-8f8dd946534f
a e000ea8d-5599-413a-8831-efc4939baa01
```

this PR
```
a 6b4c82a7-2f86-4b2a-b447-5fd42ae93a99
a 6b4c82a7-2f86-4b2a-b447-5fd42ae93a99
```
