### PR TITLE
Upload docs artifact to GitHub Actions (Cherry-pick of #778)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,3 +28,8 @@ jobs:
         encrypted_rclone_iv: ${{ secrets.encrypted_rclone_iv }}
       run: |
         tools/deploy_documentation.sh
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: html_docs
+        path: docs/_build/html


### PR DESCRIPTION
This is necessary for Qiskit/documentation to be able to build the stable docs for Provider.