### PR TITLE
switch sphinx from mathjax to katex

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,13 +27,13 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
-    'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
     'sphinx.ext.extlinks',
     'sphinx.ext.intersphinx',
     'jupyter_sphinx',
     'sphinx_autodoc_typehints',
     'reno.sphinxext',
+    'sphinxcontrib.katex',
 ]
 templates_path = ['_templates']
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,3 +26,4 @@ jupyter-sphinx
 Sphinx>=6.0.0
 sphinx-autodoc-typehints<=1.19.2
 reno>=2.11.0
+sphinxcontrib-katex==0.9.9


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Updates the sphinx documentation build to use KaTeX instead of MathJax because the final docs build uses KaTeX. The same change was made in Qiskit in https://github.com/Qiskit/qiskit/pull/11435.

### Details and comments


