### PR TITLE
Methods live on class pages

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -12,38 +12,25 @@
    :no-inherited-members:
    :no-special-members:
 
-   {% block attributes_summary %}
+{% block attributes_summary %}
    {% if attributes %}
-
    .. rubric:: Attributes
-
-   .. autosummary::
-      :toctree: ../stubs/
-   {% for item in all_attributes %}
-      {%- if not item.startswith('_') %}
-      {{ name }}.{{ item }}
-      {%- endif -%}
-   {%- endfor %}
+      {% for item in all_attributes %}
+         {%- if not item.startswith('_') %}
+   .. autoattribute:: {{ name }}.{{ item }}
+         {%- endif -%}
+      {%- endfor %}
    {% endif %}
-   {% endblock %}
+{% endblock %}
 
-   {% block methods_summary %}
+{% block methods_summary %}
    {% if methods %}
-
    .. rubric:: Methods
-
-   .. autosummary::
-      :toctree: ../stubs/
    {% for item in all_methods %}
       {%- if not item.startswith('_') or item in ['__call__', '__mul__', '__getitem__', '__len__'] %}
-      {{ name }}.{{ item }}
-      {%- endif -%}
-   {%- endfor %}
-   {% for item in inherited_members %}
-      {%- if item in ['__call__', '__mul__', '__getitem__', '__len__'] %}
-      {{ name }}.{{ item }}
+   .. automethod:: {{ name }}.{{ item }}
       {%- endif -%}
    {%- endfor %}
 
    {% endif %}
-   {% endblock %}
+{% endblock %}

--- a/qiskit_ibm_provider/ibm_backend.py
+++ b/qiskit_ibm_provider/ibm_backend.py
@@ -593,7 +593,7 @@ class IBMBackend(Backend):
 
         The schema for backend properties can be found in
         `Qiskit/ibm-quantum-schemas
-        <https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/backend_properties_schema.json>`_.
+        <https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/backend_properties_schema.json>`__.
 
         Args:
             refresh: If ``True``, re-query the server for the backend properties.
@@ -665,7 +665,7 @@ class IBMBackend(Backend):
 
         The schema for default pulse configuration can be found in
         `Qiskit/ibm-quantum-schemas
-        <https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/default_pulse_configuration_schema.json>`_.
+        <https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/default_pulse_configuration_schema.json>`__.
 
         Args:
             refresh: If ``True``, re-query the server for the backend pulse defaults.
@@ -695,7 +695,7 @@ class IBMBackend(Backend):
 
         The schema for backend configuration can be found in
         `Qiskit/ibm-quantum-schemas
-        <https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/backend_configuration_schema.json>`_.
+        <https://github.com/Qiskit/ibm-quantum-schemas/blob/main/schemas/backend_configuration_schema.json>`__.
 
         Returns:
             The configuration for the backend.


### PR DESCRIPTION
Currently, methods live on dedicated HTML pages rather than their class pages. 

But in qiskit/documentation, we merge those methods to live on the class page because it's a better user experience. While we do have code to do that, it's simpler to change Provider's config to have Sphinx do the right thing from the start.

This template is copied from qiskit-ibm-runtime.