### PR TITLE
upper cap qiskit<1 during the deprecation period

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-qiskit>=0.45.0
+qiskit>=0.45.0,<1
 requests>=2.19
 requests_ntlm>=1.1.0
 numpy>=1.13


### PR DESCRIPTION
Consider keeping qiskit-ibm-provider in the Qiskit 0.* edition and having support for it until August 2024 (when `qiskit 0.*` reaches eol).

This PR sets an upper bound version constraint on `qiskit` to avoid installing qiskit 1.0 or greater.