### PR TITLE
Update intersphinx URL for Qiskit

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ extensions = [
 templates_path = ['_templates']
 
 intersphinx_mapping = {
-    "qiskit": ("https://qiskit.org/documentation/", None),
+    "qiskit": ("https://docs.quantum.ibm.com/api/qiskit/", None),
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
### Summary

The new Qiskit documentation now supports `objects.inv`, so we can update this URL. The old URL will disappear at some point.