### PR TITLE
Fix pip environment resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -c constraints.txt -e .
-          pip install -U -c constraints.txt -r requirements-dev.txt
+          pip install -c constraints.txt -r requirements-dev.txt -e .
       - name: Run black
         run: make style
       - name: Run lint
@@ -91,8 +90,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -c constraints.txt -e .
-          pip install -U -c constraints.txt -r requirements-dev.txt
+          pip install -c constraints.txt -r requirements-dev.txt -e .
       - name: Run unit tests
         run: make unit-test-coverage
       - name: Report coverage to coveralls.io
@@ -134,8 +132,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
-          pip install -r requirements-dev.txt
+          pip install -c constraints.txt -e . -r requirements-dev.txt
       - name: Run integration tests 1
         run: make integration-test-1
   integration-tests-2:
@@ -170,8 +167,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
-          pip install -r requirements-dev.txt
+          pip install -c constraints.txt -e . -r requirements-dev.txt
       - name: Run integration tests 2
         run: make integration-test-2
   integration-tests-3:
@@ -206,8 +202,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
-          pip install -r requirements-dev.txt
+          pip install -c constraints.txt -e . -r requirements-dev.txt
       - name: Run integration tests 3
         run: make integration-test-3
   tests-finished:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -47,7 +47,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
-          pip install -r requirements-dev.txt
+          pip install -c constraints.txt -e . -r requirements-dev.txt
       - name: Run e2e tests
         run: make e2e-test

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -47,8 +47,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
-          pip install -r requirements-dev.txt
+          pip install -c constraints.txt -e . -r requirements-dev.txt
       - name: Run integration tests 1
         run: make integration-test-1
   integration-tests-2:
@@ -81,8 +80,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
-          pip install -r requirements-dev.txt
+          pip install -c constraints.txt -e . -r requirements-dev.txt
       - name: Run integration tests 2
         run: make integration-test-2
   integration-tests-3:

--- a/.github/workflows/unit-tests-terra-main.yml
+++ b/.github/workflows/unit-tests-terra-main.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   unit-tests-latest-qiskit-terra:
     if: github.repository_owner == 'Qiskit'
-    name: Run unit tests with latest code of qiskit-terra
+    name: Run unit tests with latest code of Qiskit
     runs-on: "ubuntu-latest"
     env:
       LOG_LEVEL: DEBUG
@@ -35,9 +35,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -c constraints.txt -e .
-          pip install -U -c constraints.txt -r requirements-dev.txt
-          pip install -U git+https://github.com/Qiskit/qiskit-terra.git
+          # Install all in one go to force pip's resolver to avoid invalid states.
+          pip install -c constraints.txt -e . -r requirements-dev.txt git+https://github.com/Qiskit/qiskit.git
       - name: Run tests
         # running unit tests against latest (non-released) code of qiskit-terra gives a basic level
         # of confidence that the integration between qiskit-ibm-provider and qiskit-terra works


### PR DESCRIPTION
### Summary

Calling `pip install` multiple times can (deeply unfortunately) allow an environment to become out-of-sync; `pip` doesn't "remember" the constraints of previous installation commands.

One of the largest effects here is that doing `pip install -e .` _followed_ by `pip install git+<qiskit>@main` installs `qiskit-terra` from the initial installation (via `qiskit==0.45.2`), then installs `qiskit==1.0.0.dev0` from Git, which is an incompatible environment. Doing the whole environment resolution in a single `pip install` command fixes this, as the `qiskit` dependency is correctly resolved to be _only_ the `1.0.0.dev0` version.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### Details and comments


