### PR TITLE
Fix bad tox.ini passenv setting

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,8 @@ setenv =
   VIRTUAL_ENV={envdir}
   LANGUAGE=en_US
   LC_ALL=en_US.utf-8
-passenv=
-  GITHUB_REF_NAME,
+passenv =
+  GITHUB_REF_NAME
   GITHUB_BASE_REF
 commands =
   python -m unittest -v


### PR DESCRIPTION
Fixes https://github.com/Qiskit/qiskit-ibm-provider/pull/821. 

I made a divergence from our testing in qiskit-sphinx-theme to make the INI file more readable, and I didn't properly test it. My bad!

This bug meant that we always used `main` as the branch name. I tested this out locally and it works now:

```
GITHUB_REF_NAME="pull" GITHUB_BASE_REF="upstream" tox -e docs
...
    raise ValueError(GITHUB_BRANCH)
ValueError: upstream
```